### PR TITLE
Gradle5 support bugfixes

### DIFF
--- a/src/it/junit5-native/build.gradle
+++ b/src/it/junit5-native/build.gradle
@@ -1,0 +1,27 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure'
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+allure {
+    version = '2.4.1'
+    aspectjweaver = true
+
+    useJUnit5 {
+        version = "2.0-BETA21"
+    }
+}
+
+test {
+    useJUnitPlatform()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.2'
+}

--- a/src/it/junit5-native/src/test/java/tests/Junit5Test.java
+++ b/src/it/junit5-native/src/test/java/tests/Junit5Test.java
@@ -1,0 +1,27 @@
+package tests;
+
+import io.qameta.allure.Attachment;
+import io.qameta.allure.Step;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Junit5Test {
+
+    @Test
+    public void testWithAttachment() {
+        stepMethod();
+        assertTrue(true);
+    }
+
+    @Step("step")
+    public void stepMethod() {
+        attachment();
+    }
+
+    @Attachment(value = "attachment", type = "text/plain")
+    public String attachment() {
+        return "<p>HELLO</p>";
+    }
+
+}

--- a/src/main/groovy/io/qameta/allure/gradle/AllurePlugin.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/AllurePlugin.groovy
@@ -123,7 +123,7 @@ class AllurePlugin implements Plugin<Project> {
 
     private void configureTestTasks(AllureExtension ext) {
         project.tasks.withType(Test).each {
-            it.outputs.files(project.files(project.file(ext.resultsDir)))
+            it.outputs.dir(ext.resultsDir)
             it.systemProperty(ALLURE_DIR_PROPERTY, ext.resultsDir)
         }
     }

--- a/src/main/groovy/io/qameta/allure/gradle/AllurePlugin.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/AllurePlugin.groovy
@@ -126,6 +126,12 @@ class AllurePlugin implements Plugin<Project> {
             it.outputs.dir(ext.resultsDir)
             it.systemProperty(ALLURE_DIR_PROPERTY, ext.resultsDir)
         }
+        project.tasks.withType(JavaExec).each {
+            if (it.name == 'junitPlatformTest') {
+                it.outputs.dir(ext.resultsDir)
+                it.systemProperty(ALLURE_DIR_PROPERTY, ext.resultsDir)
+            }
+        }
     }
 
     private void applyTestAspectjweaver(AllureExtension ext) {

--- a/src/test/java/io/qameta/allure/gradle/AggregatedReportTest.java
+++ b/src/test/java/io/qameta/allure/gradle/AggregatedReportTest.java
@@ -36,7 +36,8 @@ public class AggregatedReportTest {
     public static Collection<Object[]> getFrameworks() {
         return Arrays.asList(
                 new Object[]{"3.5", "src/it/report-multi", new String[]{"allureAggregatedReport"}},
-                new Object[]{"4.0", "src/it/report-multi", new String[]{"allureAggregatedReport"}}
+                new Object[]{"4.0", "src/it/report-multi", new String[]{"allureAggregatedReport"}},
+                new Object[]{"5.0", "src/it/report-multi", new String[]{"allureAggregatedReport"}}
         );
     }
 

--- a/src/test/java/io/qameta/allure/gradle/CategoriesTest.java
+++ b/src/test/java/io/qameta/allure/gradle/CategoriesTest.java
@@ -40,7 +40,8 @@ public class CategoriesTest {
     public static Collection<Object[]> getFrameworks() {
         return Arrays.asList(
                 new Object[]{"3.5", "src/it/categories", new String[]{"allureReport"}},
-                new Object[]{"4.0", "src/it/categories", new String[]{"allureReport"}}
+                new Object[]{"4.0", "src/it/categories", new String[]{"allureReport"}},
+                new Object[]{"5.0", "src/it/categories", new String[]{"allureReport"}}
         );
     }
 

--- a/src/test/java/io/qameta/allure/gradle/DependenciesTest.java
+++ b/src/test/java/io/qameta/allure/gradle/DependenciesTest.java
@@ -10,6 +10,7 @@ import org.junit.runners.Parameterized;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -24,6 +25,17 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(Parameterized.class)
 public class DependenciesTest {
+    
+    private static final String[][] IT_MATRIX = {
+        { "src/it/cucumber-jvm",         "3.5", "4.0",        "5.0" },
+        { "src/it/junit4",               "3.5", "4.0",        "5.0" },
+        { "src/it/junit4-autoconfigure", "3.5", "4.0",        "5.0" },
+        { "src/it/junit5",               "3.5", "4.0",        "5.0" },
+        { "src/it/testng",               "3.5", "4.0",        "5.0" },
+        { "src/it/testng-autoconfigure", "3.5", "4.0",        "5.0" },
+        { "src/it/spock",                "3.5", "4.0",        "5.0" },
+        { "src/it/junit5-native",                      "4.6", "5.0" },
+    };
 
     @Parameterized.Parameter(0)
     public String version;
@@ -39,23 +51,9 @@ public class DependenciesTest {
 
     @Parameterized.Parameters(name = "{1} [{0}]")
     public static Collection<Object[]> getFrameworks() {
-        return Arrays.asList(
-                new Object[]{"3.5", "src/it/cucumber-jvm"},
-                new Object[]{"4.0", "src/it/cucumber-jvm"},
-                new Object[]{"3.5", "src/it/junit4"},
-                new Object[]{"4.0", "src/it/junit4"},
-                new Object[]{"3.5", "src/it/junit4-autoconfigure"},
-                new Object[]{"4.0", "src/it/junit4-autoconfigure"},
-                new Object[]{"3.5", "src/it/junit5"},
-                new Object[]{"4.0", "src/it/junit5"},
-                new Object[]{"3.5", "src/it/testng"},
-                new Object[]{"4.0", "src/it/testng"},
-                new Object[]{"3.5", "src/it/testng-autoconfigure"},
-                new Object[]{"4.0", "src/it/testng-autoconfigure"},
-                new Object[]{"3.5", "src/it/spock"},
-                new Object[]{"4.0", "src/it/spock"}
-
-        );
+        return Arrays.stream(IT_MATRIX)
+                .flatMap(it -> Arrays.stream(it).skip(1).map(version -> new Object[] { version, it[0] }))
+                .collect(Collectors.toList());
     }
 
     @Test

--- a/src/test/java/io/qameta/allure/gradle/SingleReportTest.java
+++ b/src/test/java/io/qameta/allure/gradle/SingleReportTest.java
@@ -37,7 +37,8 @@ public class SingleReportTest {
         return Arrays.asList(
                 new Object[]{"3.5", "src/it/test-finalized-by-report", new String[]{"test"}},
                 new Object[]{"3.5", "src/it/report-task", new String[]{"allureReport"}},
-                new Object[]{"4.0", "src/it/report-task", new String[]{"allureReport"}}
+                new Object[]{"4.0", "src/it/report-task", new String[]{"allureReport"}},
+                new Object[]{"5.0", "src/it/report-task", new String[]{"allureReport"}}
         );
     }
 


### PR DESCRIPTION
### Context

Plugin incorrectly configures outputs for test task, this leads to error on Gradle 5 build:
`Cannot write to file 'build/allure-results' specified for property '$1' as it is a directory.`

Gradle 4 with `--warning-mode=all` warns about this:
`Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated and is scheduled to be removed in Gradle 5.0.`

Also during testing bugfix, issue was found with deprecated 'org.junit.platform.gradle.plugin' that was not configured with outputs and system properties and was unable to customize allure resultsDir.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
