### PR TITLE
enhance Gradle Kotlin DSL support by providing typesafe accessors

### DIFF
--- a/src/it/junit4-kotlin/build.gradle.kts
+++ b/src/it/junit4-kotlin/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    java
+    id("io.qameta.allure")
+}
+
+allure {
+    version = "2.8.1"
+    autoconfigure = true
+
+    useJUnit4 {
+        version = "2.9.0"
+    }
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}
+
+dependencies {
+    testCompile("junit:junit:4.12")
+}

--- a/src/it/junit4-kotlin/src/test/java/tests/Junit4Test.java
+++ b/src/it/junit4-kotlin/src/test/java/tests/Junit4Test.java
@@ -1,0 +1,26 @@
+package tests;
+
+import io.qameta.allure.Attachment;
+import io.qameta.allure.Step;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Junit4Test {
+
+    @Test
+    public void testWithAttachment() {
+        stepMethod();
+        Assert.assertTrue(true);
+    }
+
+    @Step("step")
+    public void stepMethod() {
+        attachment();
+    }
+
+    @Attachment(value = "attachment", type = "text/plain")
+    public String attachment() {
+        return "<p>HELLO</p>";
+    }
+
+}

--- a/src/it/junit4/build.gradle
+++ b/src/it/junit4/build.gradle
@@ -8,7 +8,7 @@ allure {
     aspectjweaver = true
 
     useJUnit4 {
-        version = "2.0-BETA21"
+        version = "2.9.0"
     }
 }
 

--- a/src/main/groovy/io/qameta/allure/gradle/AllureExtension.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/AllureExtension.groovy
@@ -1,6 +1,12 @@
 package io.qameta.allure.gradle
 
 import groovy.transform.CompileStatic
+import io.qameta.allure.gradle.config.CucumberJVMConfig
+import io.qameta.allure.gradle.config.JUnit4Config
+import io.qameta.allure.gradle.config.JUnit5Config
+import io.qameta.allure.gradle.config.SpockConfig
+import io.qameta.allure.gradle.config.TestNGConfig
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.reporting.ReportingExtension
 
@@ -26,15 +32,40 @@ class AllureExtension extends ReportingExtension {
 
     String aspectjVersion = '1.8.10'
 
-    Closure useTestNG
+    protected TestNGConfig testNGConfig
 
-    Closure useJUnit4
+    void useTestNG(Action<? super TestNGConfig> action) {
+        testNGConfig = new TestNGConfig()
+        action.execute(testNGConfig)
+    }
 
-    Closure useJUnit5
+    protected JUnit4Config junit4Config
 
-    Closure useCucumberJVM
+    void useJUnit4(Action<? super JUnit4Config> action) {
+        junit4Config = new JUnit4Config()
+        action.execute(junit4Config)
+    }
 
-    Closure useSpock
+    protected JUnit5Config junit5Config
+
+    void useJUnit5(Action<? super JUnit5Config> action) {
+        junit5Config = new JUnit5Config()
+        action.execute(junit5Config)
+    }
+
+    protected CucumberJVMConfig cucumberJVMConfig
+
+    void useCucumberJVM(Action<? super CucumberJVMConfig> action) {
+        cucumberJVMConfig = new CucumberJVMConfig()
+        action.execute(cucumberJVMConfig)
+    }
+
+    protected SpockConfig spockConfig
+
+    void useSpock(Action<? super SpockConfig> action) {
+        spockConfig = new SpockConfig()
+        action.execute(spockConfig)
+    }
 
     String version
 

--- a/src/main/groovy/io/qameta/allure/gradle/AllurePlugin.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/AllurePlugin.groovy
@@ -1,11 +1,6 @@
 package io.qameta.allure.gradle
 
 import groovy.transform.CompileStatic
-import io.qameta.allure.gradle.config.CucumberJVMConfig
-import io.qameta.allure.gradle.config.JUnit4Config
-import io.qameta.allure.gradle.config.JUnit5Config
-import io.qameta.allure.gradle.config.SpockConfig
-import io.qameta.allure.gradle.config.TestNGConfig
 import io.qameta.allure.gradle.task.AllureReport
 import io.qameta.allure.gradle.task.AllureServe
 import io.qameta.allure.gradle.task.DownloadAllure
@@ -18,7 +13,6 @@ import org.gradle.api.internal.tasks.testing.testng.TestNGTestFramework
 import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.testing.Test
 import org.gradle.process.JavaForkOptions
-import org.gradle.util.ConfigureUtil
 
 /**
  * @author Egor Borisov ehborisov@gmail.com
@@ -77,7 +71,7 @@ class AllurePlugin implements Plugin<Project> {
 
     private void autoconfigure(AllureExtension extension) {
         TEST_FRAMEWORKS.each { name, framework ->
-            boolean apply = project.tasks.withType(Test).any { task -> framework.isInstance(task.testFramework) }
+            boolean apply = project.tasks.withType(Test).any { Test task -> framework.isInstance(task.testFramework) }
             if (apply) {
                 project.logger.debug("Allure autoconfiguration: $name test framework found")
                 String dependencyString = ADAPTER_DEPENDENCIES[name] + extension.allureJavaVersion
@@ -91,26 +85,21 @@ class AllurePlugin implements Plugin<Project> {
     }
 
     private applyAdapters(AllureExtension ext) {
-        if (ext.useTestNG) {
-            TestNGConfig testNGConfig = ConfigureUtil.configure(ext.useTestNG, new TestNGConfig())
-            addAdapterDependency(ext, testNGConfig.name, testNGConfig.version, testNGConfig.spiOff)
+        if (ext.testNGConfig) {
+            addAdapterDependency(ext, ext.testNGConfig.name, ext.testNGConfig.version, ext.testNGConfig.spiOff)
         }
-        if (ext.useJUnit4) {
-            JUnit4Config junit4Config = ConfigureUtil.configure(ext.useJUnit4, new JUnit4Config())
-            addAdapterDependency(ext, junit4Config.name, junit4Config.version, false)
-            project.dependencies.add(ext.configuration, JUNIT4_ASPECT_DEPENDENCY + junit4Config.version)
+        if (ext.junit4Config) {
+            addAdapterDependency(ext, ext.junit4Config.name, ext.junit4Config.version, false)
+            project.dependencies.add(ext.configuration, JUNIT4_ASPECT_DEPENDENCY + ext.junit4Config.version)
         }
-        if (ext.useJUnit5) {
-            JUnit5Config junit5Config = ConfigureUtil.configure(ext.useJUnit5, new JUnit5Config())
-            addAdapterDependency(ext, junit5Config.name, junit5Config.version, false)
+        if (ext.junit5Config) {
+            addAdapterDependency(ext, ext.junit5Config.name, ext.junit5Config.version, false)
         }
-        if (ext.useCucumberJVM) {
-            CucumberJVMConfig cucumberConfig = ConfigureUtil.configure(ext.useCucumberJVM, new CucumberJVMConfig())
-            addAdapterDependency(ext, cucumberConfig.name, cucumberConfig.version, false)
+        if (ext.cucumberJVMConfig) {
+            addAdapterDependency(ext, ext.cucumberJVMConfig.name, ext.cucumberJVMConfig.version, false)
         }
-        if (ext.useSpock) {
-            SpockConfig spockConfig = ConfigureUtil.configure(ext.useSpock, new SpockConfig())
-            addAdapterDependency(ext, spockConfig.name, spockConfig.version, false)
+        if (ext.spockConfig) {
+            addAdapterDependency(ext, ext.spockConfig.name, ext.spockConfig.version, false)
         }
     }
 
@@ -128,30 +117,30 @@ class AllurePlugin implements Plugin<Project> {
             test.systemProperty(ALLURE_DIR_PROPERTY, ext.resultsDir)
         }
     }
-    
+
     private void applyAspectjweaver(AllureExtension ext) {
         if (ext.aspectjweaver || ext.autoconfigure) {
             Configuration aspectjConfiguration = project.configurations.maybeCreate(CONFIGURATION_ASPECTJ_WEAVER)
-            
+
             project.dependencies.add(CONFIGURATION_ASPECTJ_WEAVER, "org.aspectj:aspectjweaver:${ext.aspectjVersion}")
-            
+
             String javaAgent = "-javaagent:${aspectjConfiguration.singleFile}"
-            
+
             configureTestTasks { Task task, JavaForkOptions test ->
                 task.doFirst {
                     test.jvmArgs = [javaAgent] + test.jvmArgs as Iterable
                 }
                 if (project.logger.debugEnabled) {
                     project.logger.debug "jvmArgs for task $task.name $test.jvmArgs"
-                } 
+                }
             }
         }
     }
-    
+
     private void configureTestTasks(Closure closure) {
         [project.tasks.withType(Test), junitPlatformPluginTestTasks()].flatten().each { closure(it, it) }
     }
-    
+
     private Collection<JavaExec> junitPlatformPluginTestTasks() {
         project.tasks.withType(JavaExec).findAll { JavaExec task -> task.name == 'junitPlatformTest' }
     }

--- a/src/test/java/io/qameta/allure/gradle/DependenciesTest.java
+++ b/src/test/java/io/qameta/allure/gradle/DependenciesTest.java
@@ -25,11 +25,12 @@ import static org.junit.Assume.assumeThat;
  */
 @RunWith(Parameterized.class)
 public class DependenciesTest {
-    
+
     private static final String[][] IT_MATRIX = {
         { "src/it/cucumber-jvm",         "3.5", "4.0",        "5.0" },
         { "src/it/junit4",               "3.5", "4.0",        "5.0" },
         { "src/it/junit4-autoconfigure", "3.5", "4.0",        "5.0" },
+        { "src/it/junit4-kotlin",                             "5.0", "5.1" },
         { "src/it/junit5",               "3.5", "4.0",        "5.0" },
         { "src/it/testng",               "3.5", "4.0",        "5.0" },
         { "src/it/testng-autoconfigure", "3.5", "4.0",        "5.0" },

--- a/src/test/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
+++ b/src/test/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
@@ -71,6 +71,7 @@ public class GradleRunnerRule extends ExternalResource {
 
     protected void before() throws Throwable {
         projectDir = copyProject(projectSupplier.get());
+        new File(projectDir, "settings.gradle").createNewFile();
         buildResult = GradleRunner.create()
                 .withProjectDir(projectDir)
                 .withArguments(tasksSupplier.get())


### PR DESCRIPTION
the current version of the plugin uses Groovy Closures for configuration (e.g. _useJUnit4_). This makes it harder to use the plugin with the Gradle Kotlin DSL. this PR replaces the Closure based accessors with typesafe methods. 

#### Checklist
- [x ] [Sign Allure CLA][cla]
- [x ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2