### PR TITLE
Allow to use the allureReport task in Gradle projects that have no SourceSets

### DIFF
--- a/src/it/report-only/build.gradle
+++ b/src/it/report-only/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'io.qameta.allure'
+}
+
+allure {
+    version = '2.4.1'
+}

--- a/src/it/report-only/build/allure-results/simple-result.json
+++ b/src/it/report-only/build/allure-results/simple-result.json
@@ -1,0 +1,19 @@
+{
+  "uuid": "e8f6fd85-b5aa-4adc-afc7-d101e47537c6",
+  "historyId": "1d9b83988bf21cd8c54ca5f4cf3cedec",
+  "fullName": "FirstTest.testOutput",
+  "labels": [],
+  "links": [],
+  "name": "testOutput",
+  "status": "passed",
+  "statusDetails": {
+    "known": false,
+    "muted": false,
+    "flaky": false
+  },
+  "stage": "finished",
+  "start": 1497973191961,
+  "stop": 1497973192003,
+  "steps": [],
+  "parameters": []
+}

--- a/src/main/groovy/io/qameta/allure/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/util/BuildUtils.groovy
@@ -31,12 +31,15 @@ class BuildUtils {
 
     static void copyCategoriesInfo(File resultsDir, Project project) {
         SourceSetContainer sourceSets = (SourceSetContainer) project.properties.get('sourceSets')
-        List<File> resourcesCategoriesFiles = sourceSets.getByName('test').resources
-                .findAll { file -> (file.name == CATEGORIES_FILE_NAME) }
 
-        if (!resourcesCategoriesFiles.isEmpty()) {
-            File categoriesFile = Paths.get(resultsDir.absoluteFile.path).resolve(CATEGORIES_FILE_NAME).toFile()
-            categoriesFile.text = resourcesCategoriesFiles.first().text
+        if (sourceSets != null) {
+            List<File> resourcesCategoriesFiles = sourceSets.getByName('test').resources
+                    .findAll { file -> (file.name == CATEGORIES_FILE_NAME) }
+
+            if (!resourcesCategoriesFiles.isEmpty()) {
+                File categoriesFile = Paths.get(resultsDir.absoluteFile.path).resolve(CATEGORIES_FILE_NAME).toFile()
+                categoriesFile.text = resourcesCategoriesFiles.first().text
+            }
         }
     }
 

--- a/src/test/java/io/qameta/allure/gradle/ReportOnlyTest.java
+++ b/src/test/java/io/qameta/allure/gradle/ReportOnlyTest.java
@@ -1,0 +1,35 @@
+package io.qameta.allure.gradle;
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+
+public class ReportOnlyTest {
+
+    @Rule
+    public GradleRunnerRule gradleRunner = new GradleRunnerRule()
+            .version("5.0")
+            .project("src/it/report-only")
+            .tasks("allureReport");
+
+    @Test
+    public void allureReportGenerated() {
+        BuildResult buildResult = gradleRunner.getBuildResult();
+
+        File projectDir = gradleRunner.getProjectDir();
+
+        assertThat(buildResult.getTasks())
+                .as("allureReport task should work in projects without sourceSets")
+                .extracting("outcome")
+                .containsOnly(SUCCESS);
+
+        File resultsDir = new File(projectDir.getAbsolutePath() + "/build/allure-results");
+        assertThat(resultsDir.list()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
### Context
I'd like to be able to use allure-gradle within (non-Java) projects that have no SourceSet.
e.g. a project that uses the gradle-node-plugin to build and test a JavaScript project.  
Currently the usage of the _allureReport_ task in such projects causes an exception.

with this PR it's possible to use the _allureReport_  task in gradle projects that have no SourceSets defined.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
