### PR TITLE
Allow to use the allureReport task in Gradle projects without SourceSet

### DIFF
--- a/src/it/report-only/build.gradle
+++ b/src/it/report-only/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'io.qameta.allure'
+}
+
+allure {
+    version = '2.4.1'
+}

--- a/src/it/report-only/build/allure-results/simple-result.json
+++ b/src/it/report-only/build/allure-results/simple-result.json
@@ -1,0 +1,19 @@
+{
+  "uuid": "e8f6fd85-b5aa-4adc-afc7-d101e47537c6",
+  "historyId": "1d9b83988bf21cd8c54ca5f4cf3cedec",
+  "fullName": "FirstTest.testOutput",
+  "labels": [],
+  "links": [],
+  "name": "testOutput",
+  "status": "passed",
+  "statusDetails": {
+    "known": false,
+    "muted": false,
+    "flaky": false
+  },
+  "stage": "finished",
+  "start": 1497973191961,
+  "stop": 1497973192003,
+  "steps": [],
+  "parameters": []
+}

--- a/src/main/groovy/io/qameta/allure/gradle/util/BuildUtils.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/util/BuildUtils.groovy
@@ -38,15 +38,17 @@ class BuildUtils {
 
     static void copyCategoriesInfo(File resultsDir, Project project) {
         SourceSetContainer sourceSets = (SourceSetContainer) project.properties.get('sourceSets')
-        List<File> resourcesCategoriesFiles = sourceSets.getByName('test').resources
-                .findAll { file -> (file.name == CATEGORIES_FILE_NAME) }
+        if (sourceSets != null) {
+            List<File> resourcesCategoriesFiles = sourceSets.getByName('test').resources
+                    .findAll { file -> (file.name == CATEGORIES_FILE_NAME) }
 
-        Path resultsPath = Paths.get(resultsDir.absoluteFile.path)
-        Files.createDirectories(resultsPath)
+            Path resultsPath = Paths.get(resultsDir.absoluteFile.path)
+            Files.createDirectories(resultsPath)
 
-        if (!resourcesCategoriesFiles.isEmpty()) {
-            Path categoriesPath = resultsPath.resolve(CATEGORIES_FILE_NAME)
-            Files.write(categoriesPath, resourcesCategoriesFiles.first().text.getBytes(StandardCharsets.UTF_8))
+            if (!resourcesCategoriesFiles.isEmpty()) {
+                Path categoriesPath = resultsPath.resolve(CATEGORIES_FILE_NAME)
+                Files.write(categoriesPath, resourcesCategoriesFiles.first().text.getBytes(StandardCharsets.UTF_8))
+            }
         }
     }
 

--- a/src/test/java/io/qameta/allure/gradle/ReportOnlyTest.java
+++ b/src/test/java/io/qameta/allure/gradle/ReportOnlyTest.java
@@ -1,0 +1,35 @@
+package io.qameta.allure.gradle;
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+
+public class ReportOnlyTest {
+
+    @Rule
+    public GradleRunnerRule gradleRunner = new GradleRunnerRule()
+            .version("5.0")
+            .project("src/it/report-only")
+            .tasks("allureReport");
+
+    @Test
+    public void allureReportGenerated() {
+        BuildResult buildResult = gradleRunner.getBuildResult();
+
+        File projectDir = gradleRunner.getProjectDir();
+
+        assertThat(buildResult.getTasks())
+                .as("allureReport task should work in projects without sourceSets")
+                .extracting("outcome")
+                .containsOnly(SUCCESS);
+
+        File resultsDir = new File(projectDir.getAbsolutePath() + "/build/allure-results");
+        assertThat(resultsDir.list()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
…ets (e.g. non Java projects): checks the existence of SourceSets before using them.

[//]: # (
. Thank you so much for sending us a pull request! 
.
. Make sure you have a clear name for your pull request. 
. The name should start with a capital letter and no dot is required in the end of the sentence.
. To link the request with isses use the following notation: (fixes #123, fixes #321\)
.
. An example of good pull request names:
. - Add Russian translation (fixes #123\)
. - Add an ability to disable default plugins
. - Support emoji in test descriptions
)

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
