### PR TITLE
Add downloading of Allure CLI for 'allureServe' task

### DIFF
--- a/src/main/groovy/io/qameta/allure/gradle/task/AllureServe.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/task/AllureServe.groovy
@@ -29,6 +29,7 @@ class AllureServe extends DefaultTask {
     List<File> resultsDirs = []
 
     AllureServe() {
+        dependsOn(DownloadAllure.NAME)
         configureDefaults()
     }
 


### PR DESCRIPTION
Add downloading of Allure CLI for 'allureServe' task

### Context
[//]: # (
Describe the problem or feature in addition to a link to the issues
)
In current implementation calling of `gradle allureServe `task doesn't initiate downloading of Allure Commandline (if it is absent on the machine where the task was executed). 

For generating of Allure Report Gradle users should call `downloadReport/allureReport` tasks before.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
