### PR TITLE
Corrected spelling of commandline in error message when not found

### DIFF
--- a/src/main/groovy/io/qameta/allure/gradle/task/AllureReport.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/task/AllureReport.groovy
@@ -51,7 +51,7 @@ class AllureReport extends DefaultTask implements Reporting<AllureReportContaine
         Path allureExecutable = allureHome.resolve('bin').resolve(BuildUtils.allureExecutable).toAbsolutePath()
 
         if (Files.notExists(allureExecutable)) {
-            logger.warn("Cannot find allure commanline in $allureHome")
+            logger.warn("Cannot find allure commandline in $allureHome")
             return
         }
 

--- a/src/main/groovy/io/qameta/allure/gradle/task/AllureServe.groovy
+++ b/src/main/groovy/io/qameta/allure/gradle/task/AllureServe.groovy
@@ -38,7 +38,7 @@ class AllureServe extends DefaultTask {
         Path allureExecutable = allureHome.resolve('bin').resolve(BuildUtils.allureExecutable).toAbsolutePath()
 
         if (Files.notExists(allureExecutable)) {
-            logger.warn("Cannot find allure commanline in $allureHome")
+            logger.warn("Cannot find allure commandline in $allureHome")
             return
         }
 


### PR DESCRIPTION
### Context
[//]: # (
When generating a report, if the commandline was not downloaded, there was a spelling mistake in the error message.
)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
