### PR TITLE
Avoid executing tests when ./gradlew assemble is called

### DIFF
--- a/allure-adapter-plugin/src/it/adapter-assemble/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-assemble/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id("java")
+    id("io.qameta.allure-adapter")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation platform('org.junit:junit-bom:5.8.1')
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+}
+
+tasks.test {
+    useJUnitPlatform()
+    doLast {
+        throw new IllegalStateException("test task must not be called when executing ./gradlew assemble")
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-assemble/src/test/java/tests/Junit5Test.java
+++ b/allure-adapter-plugin/src/it/adapter-assemble/src/test/java/tests/Junit5Test.java
@@ -1,0 +1,27 @@
+package tests;
+
+import io.qameta.allure.Attachment;
+import io.qameta.allure.Step;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Junit5Test {
+
+    @Test
+    public void testWithAttachment() {
+        stepMethod();
+        assertTrue(true);
+    }
+
+    @Step("step")
+    public void stepMethod() {
+        attachment();
+    }
+
+    @Attachment(value = "attachment", type = "text/plain")
+    public String attachment() {
+        return "<p>HELLO</p>";
+    }
+
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterBasePlugin.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterBasePlugin.kt
@@ -8,6 +8,7 @@ import io.qameta.allure.gradle.adapter.tasks.CopyCategories
 import io.qameta.allure.gradle.util.categoryDocumentation
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.attributes.Usage
 import org.gradle.kotlin.dsl.*
 
@@ -74,5 +75,22 @@ open class AllureAdapterBasePlugin : Plugin<Project> {
         copyCategoriesElements.outgoing.artifact(copyCategories.flatMap { it.markerFile }) {
             builtBy(copyCategories)
         }
+
+        // Workaround for https://github.com/gradle/gradle/issues/6875
+        target.afterEvaluate {
+            configurations.findByName("archives")?.let { archives ->
+                removeArtifactsFromArchives(archives, rawResultElements)
+                removeArtifactsFromArchives(archives, copyCategoriesElements)
+            }
+        }
+    }
+
+    private fun Project.removeArtifactsFromArchives(archives: Configuration, elements: Configuration) {
+        val allureResultNames = elements.outgoing.artifacts.mapTo(mutableSetOf()) { it.name }
+        if (allureResultNames.isEmpty()) {
+            return
+        }
+        logger.debug("Will remove artifacts $allureResultNames (outgoing artifacts of $elements) from $archives configuration to workaround https://github.com/gradle/gradle/issues/6875")
+        archives.outgoing.artifacts.removeIf { it.name in allureResultNames }
     }
 }

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AssembleTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AssembleTest.kt
@@ -1,0 +1,54 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class AssembleTest {
+    @Rule
+    @JvmField
+    val gradleRunner = GradleRunnerRule()
+        .version { version }
+        .project { project }
+        .tasks { tasks }
+
+    @Parameterized.Parameter(0)
+    lateinit var version: String
+
+    @Parameterized.Parameter(1)
+    lateinit var project: String
+
+    @Parameterized.Parameter(2)
+    lateinit var tasks: Array<String>
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{1} [{0}]")
+        fun getFrameworks() = listOf(
+            arrayOf(
+                "7.0",
+                "src/it/adapter-assemble",
+                arrayOf("assemble")
+            ),
+            arrayOf(
+                "5.0",
+                "src/it/adapter-assemble",
+                arrayOf("assemble")
+            )
+        )
+    }
+
+    @Test
+    fun `assemble should not execute tests`() {
+        Assertions.assertThat(gradleRunner.buildResult.tasks)
+            .`as`("assemble should succeed, and test must not be executed")
+            .filteredOn { task -> task.path == ":assemble" }
+            .extracting("outcome")
+            .containsAnyOf(TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE)
+    }
+}


### PR DESCRIPTION
The issue is known as https://github.com/gradle/gradle/issues/6875,
so we workaround it by explicitly removing allure-results artifacts from archives configuration

fixes #75
