### PR TITLE
Use allure-raw-results/$taskName/allure-results so different tasks use different folders

### DIFF
--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -121,7 +121,9 @@ open class AllureAdapterExtension @Inject constructor(
         task.run {
             // Each task should store results in its own folder
             // End user should not depend on the folder name, so we do not expose it
-            val rawResults = project.layout.buildDirectory.dir("allure-results/${task.name}").get().asFile
+            // Note: it is very important that results directory is named `allure-results`, so the folder is automatically
+            // detected by Allure Jenkins plugin.
+            val rawResults = project.layout.buildDirectory.dir("allure-raw-results/${task.name}/allure-results").get().asFile
             // See https://github.com/allure-framework/allure2/issues/1236
             // We exclude categories.json since report task would copy categories right to the folder
             // of the current task

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -121,7 +121,7 @@ open class AllureAdapterExtension @Inject constructor(
         task.run {
             // Each task should store results in its own folder
             // End user should not depend on the folder name, so we do not expose it
-            val rawResults = project.layout.buildDirectory.dir("allure-results").get().asFile
+            val rawResults = project.layout.buildDirectory.dir("allure-results/${task.name}").get().asFile
             // See https://github.com/allure-framework/allure2/issues/1236
             // We exclude categories.json since report task would copy categories right to the folder
             // of the current task

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
@@ -67,7 +67,7 @@ public class DependenciesTest {
                 .extracting("outcome")
                 .containsExactly(SUCCESS);
 
-        File resultsDir = new File(gradleRunner.getProjectDir(), "build/allure-results/test");
+        File resultsDir = new File(gradleRunner.getProjectDir(), "build/allure-raw-results/test/allure-results");
         assertThat(resultsDir).as("Allure results directory")
                 .exists();
 

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
@@ -67,7 +67,7 @@ public class DependenciesTest {
                 .extracting("outcome")
                 .containsExactly(SUCCESS);
 
-        File resultsDir = new File(gradleRunner.getProjectDir(), "build/allure-results");
+        File resultsDir = new File(gradleRunner.getProjectDir(), "build/allure-results/test");
         assertThat(resultsDir).as("Allure results directory")
                 .exists();
 

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
@@ -45,7 +45,7 @@ public class TestNgSpiOffTest {
                 .filteredOn(task -> task.getPath().equals(":test") || task.getPath().equals(":allureReport"))
                 .extracting("outcome")
                 .containsExactly(SUCCESS);
-        File resultsDir = new File(projectDir.getAbsolutePath() + "/build/allure-results");
+        File resultsDir = new File(projectDir.getAbsolutePath() + "/build/allure-results/test");
         // executor.json is always generated
         assertThat(resultsDir.listFiles())
                 .filteredOn(file -> !file.getName().equals("executor.json"))

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
@@ -45,7 +45,7 @@ public class TestNgSpiOffTest {
                 .filteredOn(task -> task.getPath().equals(":test") || task.getPath().equals(":allureReport"))
                 .extracting("outcome")
                 .containsExactly(SUCCESS);
-        File resultsDir = new File(projectDir.getAbsolutePath() + "/build/allure-results/test");
+        File resultsDir = new File(projectDir.getAbsolutePath() + "/build/allure-raw-results/test/allure-results");
         // executor.json is always generated
         assertThat(resultsDir.listFiles())
                 .filteredOn(file -> !file.getName().equals("executor.json"))


### PR DESCRIPTION
Gradle best practice is to make sure different tasks output files to the different folders, so up-to-date and caching works better.

fixes #50