### PR TITLE
Support Gradle 7.5.1: workaround ClassCastException ActionNode cannot be cast to TaskNode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,11 @@ jobs:
       matrix:
         os: [ 'ubuntu', 'windows' ]
         java-version: [ '8.0.x', '11.0.x' ]
+        exclude:
+          - os: windows
+            # Java 8 + Windows cause build crashes for unknown reason
+            # https://github.com/gradle/gradle/issues/3093 might be relevant
+            java-version: '8.0.x'
     steps:
       - uses: actions/checkout@v2
 

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
@@ -34,6 +34,12 @@ class AdaptersTest {
         @Parameterized.Parameters(name = "{1} [{0}]")
         fun getFrameworks() = listOf(
             arrayOf(
+                "7.5.1",
+                "src/it/adapter-junit5-spock-kts",
+                arrayOf("printAdapters"),
+                "[AdapterConfig{junit5}, AdapterConfig{spock}]"
+            ),
+            arrayOf(
                 "7.0",
                 "src/it/adapter-junit5-spock-kts",
                 arrayOf("printAdapters"),
@@ -46,6 +52,11 @@ class AdaptersTest {
                 "[AdapterConfig{junit5}, AdapterConfig{spock}]"
             ),
             arrayOf(
+                "7.5.1",
+                "src/it/adapter-all",
+                arrayOf("printAdapters"),
+                "[AdapterConfig{cucumber2Jvm}, AdapterConfig{cucumber3Jvm}, AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumberJvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"
+            ),            arrayOf(
                 "7.0",
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/AllureExecTask.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/AllureExecTask.kt
@@ -9,6 +9,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
+import org.gradle.util.GradleVersion
 import java.io.File
 
 abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask() {
@@ -68,6 +69,12 @@ abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask(
         dependsOn(dependsOnTests.map { if (it) resultsDirs else emptyList<Any>() })
         // In any case, if user launches "./gradlew test allureReport" the report generation
         // should wait for test execution
-        mustRunAfter(resultsDirs)
+        if (GradleVersion.current() < GradleVersion.version("7.5")) {
+            mustRunAfter(resultsDirs)
+        } else {
+            // See https://github.com/allure-framework/allure-gradle/issues/90
+            // See https://github.com/gradle/gradle/issues/21962
+            mustRunAfter(resultsDirs.map { it.elements })
+        }
     }
 }

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CategoriesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CategoriesTest.java
@@ -38,6 +38,7 @@ public class CategoriesTest {
     @Parameterized.Parameters(name = "{1} [{0}]")
     public static Collection<Object[]> getFrameworks() {
         return Arrays.asList(
+                new Object[]{"7.5.1", "src/it/categories", new String[]{"allureReport"}},
                 new Object[]{"7.0", "src/it/categories", new String[]{"allureReport"}},
                 new Object[]{"5.0", "src/it/categories", new String[]{"allureReport"}},
                 new Object[]{"6.0", "src/it/categories", new String[]{"allureReport"}}

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
@@ -28,16 +28,16 @@ public class DependenciesTest {
 
     // The order of versions is newest, oldest, rest
     private static final String[][] IT_MATRIX = {
-        { "src/it/cucumber-jvm",         "7.0", "5.0", "6.0" },
-        { "src/it/cucumber2-jvm",        "7.0", "5.0", "6.0" },
-        { "src/it/junit4",               "7.0", "5.0", "6.0" },
-        { "src/it/junit4-autoconfigure", "7.0", "5.0", "6.0" },
-        { "src/it/junit4-kotlin",        "7.0", "5.1", "5.0" },
-        { "src/it/junit5",               "7.0", "5.0", "6.0" },
-        { "src/it/junit5-5.8.1",         "7.2", "5.0", "6.0" },
-        { "src/it/testng",               "7.0", "5.0", "6.0" },
-        { "src/it/testng-autoconfigure", "7.0", "5.0", "6.0" },
-        { "src/it/spock",                "7.0", "5.0", "6.0" },
+        { "src/it/cucumber-jvm",         "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/cucumber2-jvm",        "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/junit4",               "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/junit4-autoconfigure", "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/junit4-kotlin",        "7.5.1", "7.0", "5.1", "5.0" },
+        { "src/it/junit5",               "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/junit5-5.8.1",         "7.5.1", "7.2", "5.0", "6.0" },
+        { "src/it/testng",               "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/testng-autoconfigure", "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/spock",                "7.5.1", "7.0", "5.0", "6.0" },
     };
 
     @Parameterized.Parameter(0)

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
@@ -31,7 +31,7 @@ public class TestNgSpiOffTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<String> getFrameworks() {
-        return Arrays.asList("7.0", "6.0", "5.4", "5.3");
+        return Arrays.asList("7.5.1", "7.0", "6.0", "5.4", "5.3");
     }
 
     @Test

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
@@ -28,9 +28,11 @@ class DslTest {
         @JvmStatic
         @Parameterized.Parameters(name = "{1} [{0}]")
         fun getFrameworks() = listOf(
+            arrayOf("7.5.1", "src/it/full-dsl-kotlin"),
             arrayOf("7.0", "src/it/full-dsl-kotlin"),
             arrayOf("6.0", "src/it/full-dsl-kotlin"),
             arrayOf("5.0", "src/it/full-dsl-kotlin"),
+            arrayOf("7.5.1", "src/it/full-dsl-groovy"),
             arrayOf("7.0", "src/it/full-dsl-groovy"),
             arrayOf("6.0", "src/it/full-dsl-groovy"),
             arrayOf("5.0", "src/it/full-dsl-groovy")

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/TestAndAllureReportTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/TestAndAllureReportTest.kt
@@ -38,7 +38,7 @@ class TestAndAllureReportTest {
         @Parameterized.Parameters(name = "{1},  [{0}]")
         fun getFrameworks(): Array<Any> {
             val res = mutableListOf<Array<Any>>()
-            for (gradleVersion in listOf("7.2", "7.0", "6.8.3")) {
+            for (gradleVersion in listOf("7.5.1", "7.2", "7.0", "6.8.3")) {
                 for (project in listOf("src/it/junit5-5.8.1")) {
                     for (dependOnTests in listOf(true, false)) {
                         res.add(arrayOf(gradleVersion, project, dependOnTests))

--- a/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
+++ b/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
@@ -31,6 +31,7 @@ public class ReportOnlyTest {
     @Parameterized.Parameters(name = "{0} [{1}]")
     public static Collection<Object[]> getFrameworks() {
         return Arrays.asList(
+                new Object[]{"src/it/report-only", "7.5.1"},
                 new Object[]{"src/it/report-only", "7.0"},
                 new Object[]{"src/it/report-only", "5.0"},
                 new Object[]{"src/it/report-only", "6.0"}


### PR DESCRIPTION
fixes #90

### Context

* https://github.com/allure-framework/allure-gradle/issues/90
* https://github.com/gradle/gradle/issues/21962

The bug is covered with an existing test: `io.qameta.allure.gradle.report.TestAndAllureReportTest`, the only change needed was to add 7.5.1 to the set of tested versions.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
