### PR TITLE
Fix CI Test job name: mention Java version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: 'Tests (JDK ${{ matrix.jdk }}, ${{ matrix.os }})'
+    name: 'Tests (JDK ${{ matrix.java-version }}, ${{ matrix.os }})'
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### Context

Currently CI jobs are just Build JVM without version name

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
