### PR TITLE
Support usage of allure plugin from precompiled script plugins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,3 +29,8 @@ jobs:
 
       - name: Build
         run: ./gradlew --no-parallel build
+
+      - name: Build Sandbox
+        run: |
+          cd sandbox
+          ./gradlew --no-parallel build

--- a/allure-adapter-plugin/build.gradle.kts
+++ b/allure-adapter-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 group = "io.qameta.allure.gradle.adapter"
 
 dependencies {
-    implementation(project(":allure-base-plugin"))
+    api(project(":allure-base-plugin"))
     testImplementation(project(":testkit-junit4"))
     testImplementation("org.assertj:assertj-core:_")
 }

--- a/allure-plugin/build.gradle.kts
+++ b/allure-plugin/build.gradle.kts
@@ -5,8 +5,8 @@ plugins {
 group = "io.qameta.allure.gradle.allure"
 
 dependencies {
-    implementation(project(":allure-adapter-plugin"))
-    implementation(project(":allure-report-plugin"))
+    api(project(":allure-adapter-plugin"))
+    api(project(":allure-report-plugin"))
 
     testImplementation(project(":testkit-junit4"))
     testImplementation("org.assertj:assertj-core:_")

--- a/allure-report-plugin/build.gradle.kts
+++ b/allure-report-plugin/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 group = "io.qameta.allure.gradle.report"
 
 dependencies {
-    implementation(project(":allure-base-plugin"))
+    api(project(":allure-base-plugin"))
 
     testImplementation(project(":testkit-junit4"))
     testImplementation("org.assertj:assertj-core:_")

--- a/sandbox/precompiled-kotlin/build.gradle.kts
+++ b/sandbox/precompiled-kotlin/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    gradlePluginPortal()
+}
+
+dependencies {
+    // io.qameta.allure:io.qameta.allure.gradle.plugin is preferable,
+    // however Gradle does not recognize .gradle.plugin within included build,
+    // so we use io.qameta.allure.gradle.allure:allure-plugin fallback
+    implementation("io.qameta.allure.gradle.allure:allure-plugin")
+}

--- a/sandbox/precompiled-kotlin/src/main/kotlin/allure-conventions.gradle.kts
+++ b/sandbox/precompiled-kotlin/src/main/kotlin/allure-conventions.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    id("java")
+    id("io.qameta.allure")
+}
+
+val allureVersion = "2.17.22"
+
+allure {
+    version.set(allureVersion)
+}
+
+allure.version.set(allureVersion)
+allure.adapter.allureJavaVersion.set(allureVersion)
+allure.adapter.aspectjWeaver.set(true)

--- a/sandbox/settings.gradle.kts
+++ b/sandbox/settings.gradle.kts
@@ -13,3 +13,4 @@ includeBuild("../")
 
 include("dsl-kotlin")
 include("dsl-groovy")
+include("precompiled-kotlin")


### PR DESCRIPTION
### Context

* https://github.com/allure-framework/allure-gradle/issues/84

Use "api" instead of "implementation" dependencies, otherwise Kotlin DSL accessors are not available in precompiled plugins.
 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
