### PR TITLE
Support propagating environment variables to allure execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ allure {
         allureJavaVersion.set("2.19.0")
         aspectjVersion.set("1.9.5")
 
+        // Customize environment variables for launching Allure
+        environment.put("JAVA_HOME", "/path/to/java_home")
+
         autoconfigure.set(true)
         autoconfigureListeners.set(true)
         aspectjWeaver.set(true)

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
@@ -46,7 +46,7 @@ class AdaptersTest {
                 "[AdapterConfig{junit5}, AdapterConfig{spock}]"
             ),
             arrayOf(
-                "5.0",
+                "6.0",
                 "src/it/adapter-junit5-spock-kts",
                 arrayOf("printAdapters"),
                 "[AdapterConfig{junit5}, AdapterConfig{spock}]"
@@ -56,14 +56,15 @@ class AdaptersTest {
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),
                 "[AdapterConfig{cucumber2Jvm}, AdapterConfig{cucumber3Jvm}, AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumberJvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"
-            ),            arrayOf(
+            ),
+            arrayOf(
                 "7.0",
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),
                 "[AdapterConfig{cucumber2Jvm}, AdapterConfig{cucumber3Jvm}, AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumberJvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"
             ),
             arrayOf(
-                "5.0",
+                "6.0",
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),
                 "[AdapterConfig{cucumber2Jvm}, AdapterConfig{cucumber3Jvm}, AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumberJvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AssembleTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AssembleTest.kt
@@ -36,7 +36,7 @@ class AssembleTest {
                 arrayOf("assemble")
             ),
             arrayOf(
-                "5.0",
+                "6.0",
                 "src/it/adapter-assemble",
                 arrayOf("assemble")
             )

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
@@ -4,6 +4,7 @@ import io.qameta.allure.gradle.util.conv
 import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.provideDelegate
@@ -11,7 +12,7 @@ import org.gradle.kotlin.dsl.provideDelegate
 /**
  * Provides API for configuring common properties for Allure.
  */
-open class AllureExtension(
+abstract class AllureExtension(
     objects: ObjectFactory
 ) {
     companion object {
@@ -22,6 +23,11 @@ open class AllureExtension(
      * `allure-commandline` version
      */
     val version: Property<String> = objects.property<String>().conv("2.19.0")
+
+    /**
+     * Default environment variables for launching `allure-commandline`.
+     */
+    abstract val environment: MapProperty<String, Any>
 
     // TODO: remove when deprecated [aspectjweaver] is removed
     private val aspectjWeaver by lazy {

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/AllureExecTask.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/AllureExecTask.kt
@@ -1,18 +1,21 @@
 package io.qameta.allure.gradle.base.tasks
 
+import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.util.conv
 import org.apache.tools.ant.taskdefs.condition.Os
-import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.the
 import org.gradle.util.GradleVersion
 import java.io.File
 
-abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask() {
+abstract class AllureExecTask constructor(objects: ObjectFactory) : Exec() {
     @InputDirectory
     @PathSensitive(PathSensitivity.NONE)
     val allureHome = objects.directoryProperty()
@@ -21,9 +24,26 @@ abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask(
     @Option(option = "verbose", description = "Switch on the verbose mode")
     val verbose = objects.property<Boolean>().conv(false)
 
+    /**
+     * Gradle's [Exec.executable] does not support [Provider<String>], and it uses [Object.toString],
+     * so we create an object that calls [Provider.get] in its [Object.toString].
+     */
+    protected fun<T> Provider<T>.lazyToString() = object {
+        override fun toString(): String = this@lazyToString.get().toString()
+    }
+
+    /**
+     * We might need to recover values from [Provider] values stored in [Exec.getEnvironment]
+     * when launching process via [ProcessBuilder].
+     */
+    private fun unwrapProvider(value: Any): String = when (value) {
+        is Provider<*> -> unwrapProvider(value.get())
+        else -> value.toString()
+    }
+
     @get:Internal
-    protected val allureExecutable: File
-        get() {
+    protected val allureExecutable = objects.property<File>().conv(
+        project.provider {
             val homeDir = allureHome.get().asFile
             val binDir = homeDir.resolve("bin")
 
@@ -35,9 +55,11 @@ abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask(
             if (!allureExecutable.exists()) {
                 throw IllegalArgumentException("Cannot find allure commandline in $homeDir")
             }
+
             allureExecutable.setExecutable(true)
-            return allureExecutable
+            allureExecutable
         }
+    )
 
     // InputDirectories does not exist yet: https://github.com/gradle/gradle/issues/7485#issuecomment-585289792
     @Internal
@@ -56,16 +78,20 @@ abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask(
     val dependsOnTests = objects.property<Boolean>().conv(false)
 
     @get:Internal
-    protected val rawResults: FileCollection
-        get() =
-            resultsDirs.get().filter { it.exists() && it.isDirectory }
+    protected val rawResults: Provider<FileCollection> =
+        resultsDirs.map { it.filter { it.exists() && it.isDirectory } }
 
     @InputFiles
     @SkipWhenEmpty
+    @IgnoreEmptyDirectories
     @PathSensitive(PathSensitivity.RELATIVE)
     protected val inputFiles = project.files(resultsDirs.map { dirs -> dirs.map { project.fileTree(it) } })
 
+    @get:Internal
+    protected abstract val defaultEnvironment: MapProperty<String, Any>
+
     init {
+        defaultEnvironment.convention(project.the<AllureExtension>().environment)
         dependsOn(dependsOnTests.map { if (it) resultsDirs else emptyList<Any>() })
         // In any case, if user launches "./gradlew test allureReport" the report generation
         // should wait for test execution
@@ -76,5 +102,16 @@ abstract class AllureExecTask constructor(objects: ObjectFactory) : DefaultTask(
             // See https://github.com/gradle/gradle/issues/21962
             mustRunAfter(resultsDirs.map { it.elements })
         }
+    }
+
+    override fun exec() {
+        val environment = environment
+        for ((key, value) in defaultEnvironment.get()) {
+            if (key !in environment) {
+                logger.info("Adding $key to environment properties (value omitted for security reasons)")
+                environment[key] = unwrapProvider(value)
+            }
+        }
+        super.exec()
     }
 }

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 allure {
     version = "42.0"
+    environment["TZ"] = "UTC"
     adapter {
         frameworks {
             junit5 {

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 allure {
     version.set("42.0")
+    environment.put("TZ", "UTC")
     adapter {
         frameworks {
             junit5 {

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/AggregatedReportTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/AggregatedReportTest.java
@@ -35,8 +35,8 @@ public class AggregatedReportTest {
     @Parameterized.Parameters(name = "{1} [{0}]")
     public static Collection<Object[]> getFrameworks() {
         return Arrays.asList(
+                new Object[]{"7.5.1", "src/it/report-multi", new String[]{"allureAggregateReport"}},
                 new Object[]{"7.0", "src/it/report-multi", new String[]{"allureAggregateReport"}},
-                new Object[]{"5.0", "src/it/report-multi", new String[]{"allureAggregateReport"}},
                 new Object[]{"6.0", "src/it/report-multi", new String[]{"allureAggregateReport"}}
         );
     }

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CategoriesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CategoriesTest.java
@@ -40,7 +40,6 @@ public class CategoriesTest {
         return Arrays.asList(
                 new Object[]{"7.5.1", "src/it/categories", new String[]{"allureReport"}},
                 new Object[]{"7.0", "src/it/categories", new String[]{"allureReport"}},
-                new Object[]{"5.0", "src/it/categories", new String[]{"allureReport"}},
                 new Object[]{"6.0", "src/it/categories", new String[]{"allureReport"}}
         );
     }

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
@@ -28,16 +28,16 @@ public class DependenciesTest {
 
     // The order of versions is newest, oldest, rest
     private static final String[][] IT_MATRIX = {
-        { "src/it/cucumber-jvm",         "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/cucumber2-jvm",        "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/junit4",               "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/junit4-autoconfigure", "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/junit4-kotlin",        "7.5.1", "7.0", "5.1", "5.0" },
-        { "src/it/junit5",               "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/junit5-5.8.1",         "7.5.1", "7.2", "5.0", "6.0" },
-        { "src/it/testng",               "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/testng-autoconfigure", "7.5.1", "7.0", "5.0", "6.0" },
-        { "src/it/spock",                "7.5.1", "7.0", "5.0", "6.0" },
+        { "src/it/cucumber-jvm",         "7.5.1", "7.0", "6.0" },
+        { "src/it/cucumber2-jvm",        "7.5.1", "7.0", "6.0" },
+        { "src/it/junit4",               "7.5.1", "7.0", "6.0" },
+        { "src/it/junit4-autoconfigure", "7.5.1", "7.0", "6.0" },
+        { "src/it/junit4-kotlin",        "7.5.1", "7.0", "6.0" },
+        { "src/it/junit5",               "7.5.1", "7.0", "6.0" },
+        { "src/it/junit5-5.8.1",         "7.5.1", "7.2", "6.0" },
+        { "src/it/testng",               "7.5.1", "7.0", "6.0" },
+        { "src/it/testng-autoconfigure", "7.5.1", "7.0", "6.0" },
+        { "src/it/spock",                "7.5.1", "7.0", "6.0" },
     };
 
     @Parameterized.Parameter(0)

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
@@ -31,7 +31,7 @@ public class TestNgSpiOffTest {
 
     @Parameterized.Parameters(name = "{0}")
     public static Collection<String> getFrameworks() {
-        return Arrays.asList("7.5.1", "7.0", "6.0", "5.4", "5.3");
+        return Arrays.asList("7.5.1", "7.0", "6.0");
     }
 
     @Test

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
@@ -31,11 +31,9 @@ class DslTest {
             arrayOf("7.5.1", "src/it/full-dsl-kotlin"),
             arrayOf("7.0", "src/it/full-dsl-kotlin"),
             arrayOf("6.0", "src/it/full-dsl-kotlin"),
-            arrayOf("5.0", "src/it/full-dsl-kotlin"),
             arrayOf("7.5.1", "src/it/full-dsl-groovy"),
             arrayOf("7.0", "src/it/full-dsl-groovy"),
-            arrayOf("6.0", "src/it/full-dsl-groovy"),
-            arrayOf("5.0", "src/it/full-dsl-groovy")
+            arrayOf("6.0", "src/it/full-dsl-groovy")
         )
     }
 

--- a/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
+++ b/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
@@ -33,7 +33,6 @@ public class ReportOnlyTest {
         return Arrays.asList(
                 new Object[]{"src/it/report-only", "7.5.1"},
                 new Object[]{"src/it/report-only", "7.0"},
-                new Object[]{"src/it/report-only", "5.0"},
                 new Object[]{"src/it/report-only", "6.0"}
         );
     }

--- a/sandbox/dsl-groovy/build.gradle
+++ b/sandbox/dsl-groovy/build.gradle
@@ -8,8 +8,9 @@ dependencies {
 }
 
 allure {
-    version = '2.15.0'
-    adapter {
-        allureJavaVersion = '2.15.0'
-    }
+    environment["TZ"] = "UTC"
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
 }

--- a/sandbox/dsl-kotlin/build.gradle.kts
+++ b/sandbox/dsl-kotlin/build.gradle.kts
@@ -8,8 +8,9 @@ dependencies {
 }
 
 allure {
-    version.set("2.15.0")
-    adapter {
-        allureJavaVersion.set("2.15.0")
-    }
+    environment.put("TZ", "UTC")
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
 }

--- a/testkit-junit4/src/main/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
+++ b/testkit-junit4/src/main/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
@@ -1,25 +1,22 @@
 package io.qameta.allure.gradle.rule;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.gradle.api.JavaVersion;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.util.GradleVersion;
+import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.rules.ExternalResource;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
@@ -93,8 +90,8 @@ public class GradleRunnerRule extends ExternalResource {
 
         // tasks.named requires Gradle 5.0+
         // Configuration avoidance tasks.register requires Gradle 4.9+
-        if (testGradle.compareTo(GradleVersion.version("5.0")) < 0) {
-            Assume.assumeTrue("Gradle " + testGradle + " is not supported, please upgrade to 5.0+", false);
+        if (testGradle.compareTo(GradleVersion.version("6.0")) < 0) {
+            Assert.fail("allure-gradle plugin requires Gradle 6.0+, the can't launch tests with Gradle " + testGradle);
         }
 
         Optional<JavaGradle> gradleRequirement = Stream.of(


### PR DESCRIPTION
This PR makes `AllureReport` and `AllureServe` tasks extend `org.gradle.api.tasks.Exec`, so extra environment variables and arguments could be passed via `org.gradle.process.ProcessForkOptions`.

As an extra option, default values for `environment variables` could be configure via `allure` project extension:

```
allure {
    environment.put("JAVA_HOME", "/path")
}
```

fixes #81

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
