### PR TITLE
Bump default Allure version from 2.13.6 to 2.19.0, AspectJ from 1.9.5 to 1.9.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ provide Allure results.
 Data collecting is implemented via `io.qameta.allure-adapter` Gradle plugin.
 
 The values in the sample below are the defaults.
-The sample uses Kotlin DSL. In Groovy DSL you could use `allureJavaVersion = "2.13.9"`, however, that is the only difference.
+The sample uses Kotlin DSL. In Groovy DSL you could use `allureJavaVersion = "2.19.0"`, however, that is the only difference.
 
 ```kotlin
 allure {
+    version.set("2.19.0")
     adapter {
         // Configure version for io.qameta.allure:allure-* adapters
-        allureJavaVersion.set("2.13.9")
+        // It defaults to allure.version
+        allureJavaVersion.set("2.19.0")
         aspectjVersion.set("1.9.5")
 
         autoconfigure.set(true)

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -4,6 +4,7 @@ import groovy.json.JsonOutput
 import io.qameta.allure.gradle.base.tasks.ConditionalArgumentProvider
 import io.qameta.allure.gradle.base.tasks.JavaAgentArgumentProvider
 import io.qameta.allure.gradle.adapter.config.*
+import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.util.conv
 import io.qameta.allure.gradle.util.forUseAtConfigurationTimeBackport
 import org.gradle.api.Action
@@ -40,9 +41,9 @@ open class AllureAdapterExtension @Inject constructor(
     /**
      * `allure-java` version (adapters for test engines)
      */
-    val allureJavaVersion: Property<String> = objects.property<String>().conv("2.13.9")
+    val allureJavaVersion: Property<String> = objects.property<String>().conv(project.the<AllureExtension>().version)
         .forUseAtConfigurationTimeBackport()
-    val aspectjVersion: Property<String> = objects.property<String>().conv("1.9.5")
+    val aspectjVersion: Property<String> = objects.property<String>().conv("1.9.9.1")
 
 
     /**

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
@@ -21,7 +21,7 @@ open class AllureExtension(
     /**
      * `allure-commandline` version
      */
-    val version: Property<String> = objects.property<String>().conv("2.13.6")
+    val version: Property<String> = objects.property<String>().conv("2.19.0")
 
     // TODO: remove when deprecated [aspectjweaver] is removed
     private val aspectjWeaver by lazy {

--- a/allure-plugin/src/it/junit4-autoconfigure/build.gradle
+++ b/allure-plugin/src/it/junit4-autoconfigure/build.gradle
@@ -3,10 +3,6 @@ plugins {
     id 'io.qameta.allure'
 }
 
-allure {
-    version = '2.8.0'
-}
-
 repositories {
     mavenCentral()
 }


### PR DESCRIPTION
### Context

Bump the defaults.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
