### PR TITLE
Support configuration cache in DownloadAllure task

### DIFF
--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/DownloadAllure.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/DownloadAllure.kt
@@ -3,6 +3,7 @@ package io.qameta.allure.gradle.download.tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.RelativePath
+import org.gradle.api.internal.file.FileOperations
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.property
@@ -13,7 +14,7 @@ import javax.inject.Inject
  * It would probably be better to use Gradle 6.1 [org.gradle.api.services.BuildService] to keep
  * a single Allure binary across all subprojects.
  */
-open class DownloadAllure @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+abstract class DownloadAllure @Inject constructor(objects: ObjectFactory) : DefaultTask() {
     @InputFiles
     @PathSensitive(PathSensitivity.NONE)
     val allureCommandLine = objects.property<Configuration>()
@@ -21,12 +22,15 @@ open class DownloadAllure @Inject constructor(objects: ObjectFactory) : DefaultT
     @OutputDirectory
     val destinationDir = project.layout.buildDirectory.dir("allure/commandline")
 
+    @get:Inject
+    protected abstract val fileOperations: FileOperations
+
     @TaskAction
     fun downloadAllure() {
         logger.info("Unpacking Allure Commandline to ${destinationDir.get()}")
-        val result = project.sync {
+        val result = fileOperations.sync {
             into(destinationDir)
-            from(project.zipTree(allureCommandLine.get().singleFile)) {
+            from(fileOperations.zipTree(allureCommandLine.get().singleFile)) {
                 eachFile {
                     // Replace "allure-.../abc/..." with "abc/..." for predictable folder locations
                     relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray())


### PR DESCRIPTION
### Context

https://github.com/gradle/cc-hackathon-2022

Depends on https://github.com/allure-framework/allure-gradle/pull/98 (needs Gradle 6+)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
