### PR TITLE
Add cancel-in-progress so PR builds do not wait stale jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,13 @@ on:
     branches:
       - 'master'
 
+concurrency:
+  # On master/release, we don't want any jobs cancelled
+  # On PR branches, we cancel the job if new commits are pushed
+  # More info: https://stackoverflow.com/a/70972844/1261287
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
 jobs:
   build:
     name: 'Tests (JDK ${{ matrix.java-version }}, ${{ matrix.os }})'


### PR DESCRIPTION
### Context

Stale PR jobs should be cancelled automatically.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
