### PR TITLE
Fix: allureReport tasks NO-SOURCES

### DIFF
--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -98,7 +98,11 @@ open class AllureAdapterExtension @Inject constructor(
 
     fun gatherResultsFrom(tasks: TaskCollection<out Task>) {
         project.apply<AllureAdapterBasePlugin>()
-        tasks.names.onEach { exposeArtifact(tasks.named(it))  }
+        project.afterEvaluate {
+            tasks.names.forEach {
+                exposeArtifact(tasks.named(it))
+            }
+        }
         tasks.configureEach {
             internalGatherResultsFrom(this)
         }


### PR DESCRIPTION
### Context
In #103 I used `tasks.names` but forgot it's not a live collection, so I need afterEvaluate here

Without it, the task doesn't run because there are no sources for it.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
