### PR TITLE
Expand built-in test framework support and refresh Allure defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Groovy DSL:
 
 ```groovy
 allure {
-    version = "2.34.1"
+    version = "2.38.1"
 }
 ```
 
@@ -63,7 +63,7 @@ Kotlin DSL:
 
 ```kotlin
 allure {
-    version = "2.34.1"
+    version = "2.38.1"
 }
 ```
 
@@ -94,16 +94,16 @@ provide Allure results.
 Data collecting is implemented via `io.qameta.allure-adapter` Gradle plugin.
 
 The values in the sample below are the defaults.
-The sample uses Kotlin DSL. In Groovy DSL you could use `allureJavaVersion = "2.19.0"`, however, that is the only difference.
+The sample uses Kotlin DSL. In Groovy DSL you could use `allureJavaVersion = "2.33.0"`, however, that is the only difference.
 
 ```kotlin
 allure {
-    version.set("2.34.1")
+    version.set("2.38.1")
     adapter {
         // Configure version for io.qameta.allure:allure-* adapters
-        // It defaults to allure.version
-        allureJavaVersion.set("2.29.1")
-        aspectjVersion.set("1.9.22.1")
+        // It defaults to the latest supported allure-java release
+        allureJavaVersion.set("2.33.0")
+        aspectjVersion.set("1.9.24")
 
         // Customize environment variables for launching Allure
         environment.put("JAVA_HOME", "/path/to/java_home")
@@ -116,27 +116,36 @@ allure {
         // However, it would be better to put the file in a well-known location and configure it explicitly
         categoriesFile.set(layout.projectDirectory.file("config/allure/categories.json"))
         frameworks {
+            junit4 {
+                adapterVersion.set("...")
+                enabled.set(true)
+            }
             junit5 {
                 // Defaults to allureJavaVersion
                 adapterVersion.set("...")
                 enabled.set(true)
-                // Enables allure-junit4 default test listeners via META-INF/services/...
+                // Enables allure-junit5 default test listeners via META-INF/services/...
                 autoconfigureListeners.set(true)
             }
-            junit4 {
-                // same as junit5
+            junitPlatform {
+                autoconfigureListeners.set(true)
             }
             testng {
-                // same as junit5
+                adapterVersion.set("...")
+                enabled.set(true)
+                autoconfigureListeners.set(true)
             }
+            jbehave
+            jbehave5
+            karate {
+                autoconfigureListeners.set(true)
+            }
+            scalatest
             spock
-            cucumberJvm
-            // Alternative syntax: cucumberJvm(2) {...}
-            cucumber2Jvm
-            cucumber3Jvm
             cucumber4Jvm
             cucumber5Jvm
             cucumber6Jvm
+            cucumber7Jvm
         }
     }
 }
@@ -171,7 +180,7 @@ allureRawResultElements.outgoing.artifact(file("...")) {
 
 ### Using custom JUnit5 listeners instead of the default ones
 
-`allure-java` comes with a set of default listeners for JUnit4, JUnit5, and TestNG.
+`allure-java` comes with a set of default listeners for JUnit5, JUnit Platform, Karate, and TestNG.
 However, you might want to disable them and use your own ones.
 
 Here's how you disable default listeners:
@@ -343,7 +352,7 @@ If you have a customized version, you could configure it as follows:
 ```kotlin
 allure {
     // This configures the common Allure version, so it is used for commandline as well
-    version.set("2.34.1")
+    version.set("2.38.1")
 
     commandline {
         // The following patterns are supported: `[group]`, `[module]`, `[version]`, `[extension]`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Allure plugin for Gradle [![Build](https://github.com/allure-framework/allure-gradle/actions/workflows/build.yml/badge.svg)](https://github.com/allure-framework/allure-gradle/actions/workflows/build.yml) [![release-badge][]][release]
 
-Gradle projects plugins for building [Allure](https://docs.qameta.io/allure/latest/) reports for TestNG, JUnit4, JUnit5, Cucumber JVM, and Spock tests.
+Gradle project plugins for building [Allure](https://docs.qameta.io/allure/latest/) reports for JBehave 4/5, JUnit 4/5/Platform, Karate, ScalaTest, TestNG, Cucumber JVM 4-7, and Spock tests.
 
 ## Basic usage
 

--- a/allure-adapter-plugin/src/it/adapter-resolution-cucumber4-jvm/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-cucumber4-jvm/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'io.cucumber:cucumber-core:4.8.1'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-cucumber5-jvm/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-cucumber5-jvm/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'io.cucumber:cucumber-core:5.7.0'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-cucumber6-jvm/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-cucumber6-jvm/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'io.cucumber:cucumber-core:6.11.0'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-cucumber7-jvm/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-cucumber7-jvm/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'io.cucumber:cucumber-core:7.13.0'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-jbehave/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-jbehave/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.jbehave:jbehave-core:4.8.3'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-jbehave5/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-jbehave5/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.jbehave:jbehave-core:5.1.1'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-junit-platform/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-junit-platform/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.2'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-junit4/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-junit4/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'junit:junit:4.13.2'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-junit5/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-junit5/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-karate/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-karate/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'com.intuit.karate:karate-core:1.4.1'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-scalatest-212/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-scalatest-212/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.scalatest:scalatest_2.12:3.2.19'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-scalatest-213/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-scalatest-213/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.scalatest:scalatest_2.13:3.2.19'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-spock/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-spock/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-resolution-testng-unsupported/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-testng-unsupported/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.14.3'
+    testImplementation 'org.testng:testng:6.8'
 }
 
 tasks.register('writeResolvedArtifacts') {

--- a/allure-adapter-plugin/src/it/adapter-resolution-testng/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-testng/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.testng:testng:6.8'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -35,13 +35,14 @@ open class AllureAdapterExtension @Inject constructor(
     companion object {
         const val NAME = "adapter"
         const val EXECUTOR_FILE_NAME = "executor.json"
+        const val DEFAULT_ALLURE_JAVA_VERSION = "2.33.0"
     }
 
     /**
      * `allure-java` version (adapters for test engines)
      */
     val allureJavaVersion: Property<String> =
-        objects.property<String>().convention("2.29.1")
+        objects.property<String>().convention(DEFAULT_ALLURE_JAVA_VERSION)
     val aspectjVersion: Property<String> = objects.property<String>().convention("1.9.24")
 
 

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AdapterConfig.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AdapterConfig.kt
@@ -1,6 +1,5 @@
 package io.qameta.allure.gradle.adapter.config
 
-import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.adapter.AllureAdapterExtension
 import io.qameta.allure.gradle.adapter.autoconfigure.AutoconfigureRule
 import io.qameta.allure.gradle.adapter.autoconfigure.AutoconfigureRuleBuilder
@@ -18,7 +17,7 @@ open class AdapterConfig @Inject constructor(
 ) {
     /**
      * Configures `allure-java` version for the current adapter.
-     * The value defaults to [AllureExtension.allureJavaVersion]
+     * The value defaults to [AllureAdapterExtension.allureJavaVersion]
      */
     val adapterVersion = objects.property<String>()
         .convention(allureAdapterExtension.allureJavaVersion)

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AdapterHandler.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AdapterHandler.kt
@@ -12,6 +12,11 @@ open class AdapterHandler @Inject constructor(
 
     val junit4 by lazyCreating
     val junit5 by lazyCreating
+    val junitPlatform by lazyCreating
+    val jbehave by lazyCreating
+    val jbehave5 by lazyCreating
+    val karate by lazyCreating
+    val scalatest by lazyCreating
     val testng by lazyCreating
     val spock by lazyCreating
     val cucumber4Jvm by lazyCreating

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AllureJavaAdapter.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AllureJavaAdapter.kt
@@ -23,10 +23,49 @@ internal enum class AllureJavaAdapter(
             compileAndRuntimeWithServices(adapterDependency, trimServicesFromJar)
         }
     }),
+    junitPlatform("junit-platform", {
+        supportsAutoconfigureListeners.set(true)
+        activateOn("org.junit.platform:junit-platform-launcher") {
+            compileAndRuntimeWithServices(adapterDependency, trimServicesFromJar)
+        }
+    }),
     testng("testng", {
         supportsAutoconfigureListeners.set(true)
         activateOn("org.testng:testng") {
+            matching {
+                versionAtLeast(it.version, 6, 14, 3)
+            }
             compileAndRuntimeWithServices(adapterDependency, trimServicesFromJar)
+        }
+    }),
+    jbehave("jbehave", {
+        activateOn("org.jbehave:jbehave-core") {
+            matching {
+                it.version.startsWith("4.")
+            }
+            compileAndRuntime(adapterDependency)
+        }
+    }),
+    jbehave5("jbehave5", {
+        activateOn("org.jbehave:jbehave-core") {
+            matching {
+                it.version.startsWith("5.")
+            }
+            compileAndRuntime(adapterDependency)
+        }
+    }),
+    karate("karate", {
+        supportsAutoconfigureListeners.set(true)
+        activateOn("com.intuit.karate:karate-core") {
+            compileAndRuntimeWithServices(adapterDependency, trimServicesFromJar)
+        }
+    }),
+    scalatest("scalatest", {
+        activateOn("org.scalatest:scalatest_2.12") {
+            compileAndRuntime(adapterVersion.map { "io.qameta.allure:allure-scalatest_2.12:$it" })
+        }
+        activateOn("org.scalatest:scalatest_2.13") {
+            compileAndRuntime(adapterVersion.map { "io.qameta.allure:allure-scalatest_2.13:$it" })
         }
     }),
     // Spock 2 runs on JUnit Platform, Allure provides allure-spock2 for it
@@ -81,6 +120,21 @@ internal enum class AllureJavaAdapter(
                     BaseTrimMetaInfServices.NO_SPI_JAR
                 )
             }
+        }
+
+        private fun versionAtLeast(version: String, vararg minimum: Int): Boolean {
+            val actual = version.substringBefore('-')
+                .split('.')
+                .map { it.toIntOrNull() ?: 0 }
+
+            for (index in 0 until maxOf(actual.size, minimum.size)) {
+                val actualPart = actual.getOrElse(index) { 0 }
+                val minimumPart = minimum.getOrElse(index) { 0 }
+                if (actualPart != minimumPart) {
+                    return actualPart > minimumPart
+                }
+            }
+            return true
         }
     }
 }

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
@@ -55,19 +55,19 @@ class AdaptersTest {
                 "9.0.0",
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),
-                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"
+                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]"
             ),
             arrayOf(
                 "8.11.1",
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),
-                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"
+                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]"
             ),
             arrayOf(
                 "8.14.3",
                 "src/it/adapter-all",
                 arrayOf("printAdapters"),
-                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{spock}, AdapterConfig{testng}]"
+                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]"
             )
         )
     }

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/SupportedFrameworksResolutionTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/SupportedFrameworksResolutionTest.kt
@@ -1,0 +1,61 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class SupportedFrameworksResolutionTest {
+    @Rule
+    @JvmField
+    val gradleRunner = GradleRunnerRule()
+        .version("9.0.0")
+        .project { project }
+        .tasks("writeResolvedArtifacts")
+
+    @Parameterized.Parameter(0)
+    lateinit var project: String
+
+    @Parameterized.Parameter(1)
+    lateinit var expectedDependency: String
+
+    companion object {
+        private const val ALLURE_JAVA_VERSION = "2.33.0"
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data() = listOf(
+            arrayOf("src/it/adapter-resolution-junit4", "io.qameta.allure:allure-junit4:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-junit5", "io.qameta.allure:allure-junit5:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-junit-platform", "io.qameta.allure:allure-junit-platform:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-testng", "io.qameta.allure:allure-testng:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-spock", "io.qameta.allure:allure-spock2:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-cucumber4-jvm", "io.qameta.allure:allure-cucumber4-jvm:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-cucumber5-jvm", "io.qameta.allure:allure-cucumber5-jvm:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-cucumber6-jvm", "io.qameta.allure:allure-cucumber6-jvm:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-cucumber7-jvm", "io.qameta.allure:allure-cucumber7-jvm:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-jbehave", "io.qameta.allure:allure-jbehave:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-jbehave5", "io.qameta.allure:allure-jbehave5:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-karate", "io.qameta.allure:allure-karate:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-scalatest-212", "io.qameta.allure:allure-scalatest_2.12:$ALLURE_JAVA_VERSION"),
+            arrayOf("src/it/adapter-resolution-scalatest-213", "io.qameta.allure:allure-scalatest_2.13:$ALLURE_JAVA_VERSION"),
+        )
+    }
+
+    @Test
+    fun `resolved runtime classpath should contain the expected adapter`() {
+        val resolved = gradleRunner.projectDir.resolve("build/resolvedArtifacts.txt").readText()
+
+        assertThat(resolved)
+            .contains(expectedDependency)
+            .doesNotContain("io.qameta.allure:allure-cucumber2-jvm:")
+            .doesNotContain("io.qameta.allure:allure-cucumber3-jvm:")
+
+        if (project.contains("spock")) {
+            assertThat(resolved).doesNotContain("io.qameta.allure:allure-spock:")
+        }
+    }
+}

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/UnsupportedFrameworksResolutionTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/UnsupportedFrameworksResolutionTest.kt
@@ -1,0 +1,23 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class UnsupportedFrameworksResolutionTest {
+    @Rule
+    @JvmField
+    val gradleRunner = GradleRunnerRule()
+        .version("9.0.0")
+        .project("src/it/adapter-resolution-testng-unsupported")
+        .tasks("writeResolvedArtifacts")
+
+    @Test
+    fun `unsupported testng versions should not resolve allure adapter`() {
+        val resolved = gradleRunner.projectDir.resolve("build/resolvedArtifacts.txt").readText()
+
+        assertThat(resolved)
+            .doesNotContain("io.qameta.allure:allure-testng:")
+    }
+}

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
@@ -16,12 +16,13 @@ abstract class AllureExtension(
 ) {
     companion object {
         const val NAME = "allure"
+        const val DEFAULT_VERSION = "2.38.1"
     }
 
     /**
      * `allure-commandline` version
      */
-    val version: Property<String> = objects.property<String>().convention("2.34.1")
+    val version: Property<String> = objects.property<String>().convention(DEFAULT_VERSION)
 
     /**
      * Default environment variables for launching `allure-commandline`.

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -14,6 +14,11 @@ allure {
                 adapterVersion = "42.0"
                 enabled = true
             }
+            junitPlatform.autoconfigureListeners = false
+            jbehave
+            jbehave5
+            karate.autoconfigureListeners = false
+            scalatest
             spock
             testng.adapterVersion = "43"
             testng.enabled = false

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -14,6 +14,15 @@ allure {
                 adapterVersion.set("42.0")
                 enabled.set(true)
             }
+            junitPlatform {
+                autoconfigureListeners.set(false)
+            }
+            jbehave
+            jbehave5
+            karate {
+                autoconfigureListeners.set(false)
+            }
+            scalatest
             spock
             testng.adapterVersion.set("43")
             testng.enabled.set(false)

--- a/allure-plugin/src/it/testng-autoconfigure/build.gradle
+++ b/allure-plugin/src/it/testng-autoconfigure/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.8'
+    testImplementation 'org.testng:testng:6.14.3'
 }
 
 test {

--- a/allure-plugin/src/it/testng-spi-off/build.gradle
+++ b/allure-plugin/src/it/testng-spi-off/build.gradle
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.8'
+    testImplementation 'org.testng:testng:6.14.3'
 }
 
 test {

--- a/allure-plugin/src/it/testng/build.gradle
+++ b/allure-plugin/src/it/testng/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    testImplementation 'org.testng:testng:6.8'
+    testImplementation 'org.testng:testng:6.14.3'
 }
 
 test {


### PR DESCRIPTION
### Context

This update makes the Gradle plugin work out of the box with a broader set of popular testing approaches, including JUnit Platform, JBehave 4 and 5, Karate, and ScalaTest, alongside the frameworks already supported. It also removes outdated automatic setup paths for older framework versions that are no longer part of the supported experience, which helps keep behavior more predictable for new users.

It also refreshes the default Allure versions so new projects start from the latest maintained baseline without extra setup. To make this reliable, the change adds coverage for every supported framework, so each one is checked and confirmed as part of the test suite.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2