### PR TITLE
Add configurable Allure results directory for adapter tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,9 @@ allure {
         // By default, categories.json is detected in src/test/resources/../categories.json,
         // However, it would be better to put the file in a well-known location and configure it explicitly
         categoriesFile.set(layout.projectDirectory.file("config/allure/categories.json"))
+
+        // Customize where adapter-managed test tasks write raw Allure results
+        resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))
         frameworks {
             junit4 {
                 adapterVersion.set("...")
@@ -158,7 +161,28 @@ If you need only one or two, specify the required ones via `frameworks {...}` bl
 
 ### Adding custom results for reporting
 
-You could add a folder with custom results via `allureRawResultElements` Gradle configuration.
+If you need to change where adapter-managed test tasks write raw results, configure
+`allure.adapter.resultsDir`:
+
+```kotlin
+allure {
+    adapter {
+        resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))
+    }
+}
+```
+
+You can also add externally produced or additional result folders via `allureRawResultElements`
+Gradle configuration.
+
+For report-only projects that do not apply `io.qameta.allure-adapter`, configure the report input
+instead:
+
+```kotlin
+dependencies {
+    allureReport(files(layout.buildDirectory.dir("custom-allure-results")))
+}
+```
 
 ```kotlin
 plugins {
@@ -397,6 +421,13 @@ dependencies {
 ```
 
 ## Technical details
+
+Most builds should use one of the end-user plugins:
+* `io.qameta.allure-adapter` for optional raw-result collection and adapter autoconfiguration
+* `io.qameta.allure-report` for report generation from configured raw results
+* `io.qameta.allure-aggregate-report` for multi-project report generation
+
+The base and download plugins are implementation building blocks for those public workflows.
 
 ### io.qameta.allure-base plugin
 

--- a/allure-adapter-plugin/src/it/adapter-custom-results-dir/build.gradle.kts
+++ b/allure-adapter-plugin/src/it/adapter-custom-results-dir/build.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("java")
+    id("io.qameta.allure-adapter")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+allure {
+    adapter {
+        resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/allure-adapter-plugin/src/it/adapter-custom-results-dir/src/test/java/tests/SimpleTest.java
+++ b/allure-adapter-plugin/src/it/adapter-custom-results-dir/src/test/java/tests/SimpleTest.java
@@ -1,0 +1,12 @@
+package tests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleTest {
+    @Test
+    void passes() {
+        assertTrue(true);
+    }
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterBasePlugin.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterBasePlugin.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.base.AllureBasePlugin
 import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.base.dsl.extensions
 import io.qameta.allure.gradle.base.metadata.AllureResultType
@@ -24,6 +25,8 @@ open class AllureAdapterBasePlugin : Plugin<Project> {
     }
 
     override fun apply(target: Project): Unit = target.run {
+        apply<AllureBasePlugin>()
+
         val allureExtension = the<AllureExtension>()
         allureExtension.extensions.create<AllureAdapterExtension>(
             AllureAdapterExtension.NAME,

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -8,6 +8,8 @@ import io.qameta.allure.gradle.base.tasks.JavaAgentArgumentProvider
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
@@ -15,9 +17,11 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.kotlin.dsl.*
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.JavaForkOptions
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -68,7 +72,12 @@ open class AllureAdapterExtension @Inject constructor(
      */
     val categoriesFile: RegularFileProperty = objects.fileProperty().convention(defaultCategoriesFile(project))
 
-    private val allureResultsDir = project.layout.buildDirectory.dir("allure-results")
+    /**
+     * Directory where instrumented tasks write Allure raw results.
+     */
+    val resultsDir: DirectoryProperty = objects.directoryProperty().convention(
+        project.layout.buildDirectory.dir("allure-results")
+    )
 
     val frameworks = AdapterHandler(project.container {
         objects.newInstance<AdapterConfig>(it, objects, this).also { adapter ->
@@ -124,16 +133,13 @@ open class AllureAdapterExtension @Inject constructor(
     // TODO: move to [AllureAdapterBasePlugin] like `allure { gatherResults { fromTask(..) } }
     private fun internalGatherResultsFrom(task: Task) {
         task.run {
-            // Each task should store results in its own folder
-            // End user should not depend on the folder name, so we do not expose it
-            val rawResults = allureResultsDir.get().asFile
             // Declare the whole results directory as an output to make it cacheable by Gradle.
             // Using a FileTree here makes the task output non-cacheable. See issue #107.
-            outputs.dir(rawResults)
+            outputs.dir(resultsDir)
 
             // Pass the path to the task
             if (this is JavaForkOptions) {
-                systemProperty(AllureAdapterPlugin.ALLURE_DIR_PROPERTY, rawResults.absolutePath)
+                jvmArgumentProviders += AllureResultsDirectoryArgumentProvider(resultsDir)
                 // We don't know if the task will execute JUnit5 engine or not,
                 // so we add extensions.autodetection.enabled to all the tasks if
                 // junit5.autoconfigureListeners is enabled
@@ -159,7 +165,7 @@ open class AllureAdapterExtension @Inject constructor(
 
             doFirst(
                 GenerateExecutorInfoAction(
-                    resultsDir = rawResults,
+                    resultsDir = resultsDir,
                     taskName = currentTaskName,
                     buildName = buildName,
                     projectPath = projectPath,
@@ -173,7 +179,7 @@ open class AllureAdapterExtension @Inject constructor(
         // Expose the gathered raw results
         val allureResults =
             project.configurations[AllureAdapterBasePlugin.ALLURE_RAW_RESULT_ELEMENTS_CONFIGURATION_NAME]
-        allureResults.outgoing.artifact(allureResultsDir) {
+        allureResults.outgoing.artifact(resultsDir) {
             builtBy(taskOrTasks)
         }
     }
@@ -206,14 +212,23 @@ open class AllureAdapterExtension @Inject constructor(
     }
 }
 
+private class AllureResultsDirectoryArgumentProvider(
+    @get:Internal
+    val resultsDir: Provider<Directory>
+) : CommandLineArgumentProvider {
+    override fun asArguments(): Iterable<String> =
+        listOf("-D${AllureAdapterPlugin.ALLURE_DIR_PROPERTY}=${resultsDir.get().asFile.absolutePath}")
+}
+
 private class GenerateExecutorInfoAction(
-    private val resultsDir: File,
+    private val resultsDir: Provider<Directory>,
     private val taskName: String,
     private val buildName: String,
     private val projectPath: String,
     private val projectVersion: String
 ) : Action<Task> {
     override fun execute(task: Task) {
+        val resultsDir = resultsDir.get().asFile
         resultsDir.mkdirs()
         val executorInfo = mapOf(
             "name" to "Gradle",

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CustomResultsDirTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CustomResultsDirTest.kt
@@ -1,0 +1,48 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class CustomResultsDirTest {
+    @Rule
+    @JvmField
+    val gradleRunner = GradleRunnerRule()
+        .version { version }
+        .project("src/it/adapter-custom-results-dir")
+        .tasks("test")
+
+    @Parameterized.Parameter
+    lateinit var version: String
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun versions() = listOf("9.0.0", "8.14.3", "8.11.1")
+    }
+
+    @Test
+    fun `adapter plugin writes raw results to custom directory`() {
+        assertThat(gradleRunner.buildResult.task(":test")?.outcome)
+            .`as`("test task outcome")
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        assertThat(gradleRunner.projectDir.resolve("build/allure-results"))
+            .`as`("default Allure results directory")
+            .doesNotExist()
+
+        val customResultsDir = gradleRunner.projectDir.resolve("build/custom-allure-results")
+        assertThat(customResultsDir)
+            .`as`("custom Allure results directory")
+            .isNotEmptyDirectory()
+        assertThat(customResultsDir.listFiles())
+            .`as`("Allure results test cases")
+            .filteredOn { file -> file.name.endsWith("result.json") }
+            .hasSize(1)
+    }
+}

--- a/allure-plugin/src/it/custom-results-dir/build.gradle
+++ b/allure-plugin/src/it/custom-results-dir/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+    id 'io.qameta.allure-report'
+}
+
+repositories {
+    mavenCentral()
+}
+
+test {
+    useJUnitPlatform()
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.0'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.0'
+}
+
+allure {
+    adapter {
+        resultsDir = layout.buildDirectory.dir("custom-allure-results")
+        // Newer allure-java fails to adapt data from JUnit5 in this fixture.
+        allureJavaVersion = "2.13.5"
+    }
+}

--- a/allure-plugin/src/it/custom-results-dir/src/test/java/tests/Junit5Test.java
+++ b/allure-plugin/src/it/custom-results-dir/src/test/java/tests/Junit5Test.java
@@ -1,0 +1,26 @@
+package tests;
+
+import io.qameta.allure.Attachment;
+import io.qameta.allure.Step;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class Junit5Test {
+
+    @Test
+    public void testWithAttachment() {
+        stepMethod();
+        assertTrue(true);
+    }
+
+    @Step("step")
+    public void stepMethod() {
+        attachment();
+    }
+
+    @Attachment(value = "attachment", type = "text/plain")
+    public String attachment() {
+        return "<p>HELLO</p>";
+    }
+}

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -9,6 +9,7 @@ allure {
     version = "42.0"
     environment["TZ"] = "UTC"
     adapter {
+        resultsDir = layout.buildDirectory.dir("custom-allure-results")
         frameworks {
             junit5 {
                 adapterVersion = "42.0"

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -9,6 +9,7 @@ allure {
     version.set("42.0")
     environment.put("TZ", "UTC")
     adapter {
+        resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))
         frameworks {
             junit5 {
                 adapterVersion.set("42.0")

--- a/allure-plugin/src/it/report-multi/build.gradle
+++ b/allure-plugin/src/it/report-multi/build.gradle
@@ -2,16 +2,14 @@ plugins {
     id 'io.qameta.allure-aggregate-report'
 }
 
-// By default, aggregate-report aggregates allprojects (current + subprojects)
-// For this IT, aggregate only :module1 and :module2 (exclude :module3 which has no data)
+// By default, aggregate-report aggregates allprojects (current + subprojects).
+// Make the project set explicit so the fixture documents all three publication modes.
 configurations.allureAggregateReport.dependencies.clear()
 dependencies {
     allureAggregateReport(project(":module1"))
     allureAggregateReport(project(":module2"))
+    allureAggregateReport(project(":module3"))
 }
-
-// Alternative example:
-// dependencies { allureAggregateReport(project(":module3")) }
 
 // allure-aggregate-report requires allure-commandline, so we need a repository here
 repositories {

--- a/allure-plugin/src/it/report-multi/module1/build.gradle
+++ b/allure-plugin/src/it/report-multi/module1/build.gradle
@@ -2,6 +2,8 @@ plugins {
     id 'io.qameta.allure-adapter'
 }
 
-dependencies {
-    allureRawResultElements(files("$buildDir/allure-results"))
+allure {
+    adapter {
+        resultsDir = layout.buildDirectory.dir("custom-allure-results")
+    }
 }

--- a/allure-plugin/src/it/report-multi/module1/build/custom-allure-results/first-result.json
+++ b/allure-plugin/src/it/report-multi/module1/build/custom-allure-results/first-result.json
@@ -1,0 +1,19 @@
+{
+  "uuid": "c0417b5d-4905-46d1-8882-560c9936af71",
+  "historyId": "1d9b83988bf21cd8c54ca5f4cf3cedec",
+  "fullName": "TestNgTest.testWithAttachment",
+  "labels": [],
+  "links": [],
+  "name": "testWithAttachment",
+  "status": "passed",
+  "statusDetails": {
+    "known": false,
+    "muted": false,
+    "flaky": false
+  },
+  "stage": "finished",
+  "start": 1497976811266,
+  "stop": 1497976811304,
+  "steps": [],
+  "parameters": []
+}

--- a/allure-plugin/src/it/report-multi/module2/build.gradle
+++ b/allure-plugin/src/it/report-multi/module2/build.gradle
@@ -1,7 +1,3 @@
 plugins {
     id 'io.qameta.allure-adapter'
 }
-
-dependencies {
-    allureRawResultElements(files("$buildDir/allure-results"))
-}

--- a/allure-plugin/src/it/report-multi/module3/build.gradle
+++ b/allure-plugin/src/it/report-multi/module3/build.gradle
@@ -1,0 +1,7 @@
+plugins {
+    id 'io.qameta.allure-adapter-base'
+}
+
+dependencies {
+    allureRawResultElements(files("$buildDir/manual-allure-results"))
+}

--- a/allure-plugin/src/it/report-multi/module3/build/manual-allure-results/third-result.json
+++ b/allure-plugin/src/it/report-multi/module3/build/manual-allure-results/third-result.json
@@ -1,10 +1,10 @@
 {
-  "uuid": "e8f6fd85-b5aa-4adc-afc7-d101e47537c6",
-  "historyId": "1d9b83988bf21cd8c54ca5f4cf3cedec",
-  "fullName": "FirstTest.testOutput",
+  "uuid": "5710e0bc-d228-4ab2-b4dd-69156e611adf",
+  "historyId": "6657c6e38283413f7d0d188a2518f1be",
+  "fullName": "ManualTest.testOutput",
   "labels": [],
   "links": [],
-  "name": "testOutput",
+  "name": "manualResult",
   "status": "passed",
   "statusDetails": {
     "known": false,

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/AggregatedReportTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/AggregatedReportTest.java
@@ -51,13 +51,23 @@ public class AggregatedReportTest {
                 .containsExactly(SUCCESS);
 
         File projectDir = gradleRunner.getProjectDir();
+        File customResultsDir = new File(projectDir, "module1/build/custom-allure-results");
+        assertThat(customResultsDir).as("Custom adapter Allure results directory")
+                .isNotEmptyDirectory();
+        File defaultResultsDir = new File(projectDir, "module2/build/allure-results");
+        assertThat(defaultResultsDir).as("Default adapter Allure results directory")
+                .isNotEmptyDirectory();
+        File manualResultsDir = new File(projectDir, "module3/build/manual-allure-results");
+        assertThat(manualResultsDir).as("Manually published Allure results directory")
+                .isNotEmptyDirectory();
+
         File reportDir = new File(projectDir, "build/reports/allure-report/allureAggregateReport");
         assertThat(reportDir).as("Allure report directory")
                 .exists();
 
         File testCasesDir = new File(reportDir, "data/test-cases");
         assertThat(testCasesDir.listFiles()).as("Allure test cases directory")
-                .isNotEmpty();
+                .hasSize(3);
 
     }
 }

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CustomResultsDirTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CustomResultsDirTest.java
@@ -1,0 +1,58 @@
+package io.qameta.allure.gradle.allure;
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule;
+import org.gradle.testkit.runner.BuildResult;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+
+@RunWith(Parameterized.class)
+public class CustomResultsDirTest {
+    @Parameterized.Parameter
+    public String version;
+
+    @Rule
+    public GradleRunnerRule gradleRunner = new GradleRunnerRule()
+            .version(() -> version)
+            .project("src/it/custom-results-dir")
+            .tasks("test", "allureReport");
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<String> getVersions() {
+        return Arrays.asList("9.0.0", "8.14.3", "8.11.1");
+    }
+
+    @Test
+    public void customResultsDirIsPublishedByAdapterAndUsedByReportTask() {
+        BuildResult buildResult = gradleRunner.getBuildResult();
+
+        assertThat(buildResult.getTasks()).as("Gradle build task statuses")
+                .filteredOn(task -> task.getPath().equals(":test") || task.getPath().equals(":allureReport"))
+                .extracting("outcome")
+                .containsExactly(SUCCESS, SUCCESS);
+
+        File projectDir = gradleRunner.getProjectDir();
+        File defaultResultsDir = new File(projectDir, "build/allure-results");
+        assertThat(defaultResultsDir).as("Default Allure results directory")
+                .doesNotExist();
+
+        File customResultsDir = new File(projectDir, "build/custom-allure-results");
+        assertThat(customResultsDir).as("Custom Allure results directory")
+                .isNotEmptyDirectory();
+        assertThat(customResultsDir.listFiles()).as("Allure results test cases")
+                .filteredOn(file -> file.getName().endsWith("result.json"))
+                .hasSize(1);
+
+        File reportDir = new File(projectDir, "build/reports/allure-report/allureReport");
+        assertThat(reportDir).as("Generated Allure report")
+                .isNotEmptyDirectory();
+    }
+}

--- a/allure-report-plugin/src/it/report-only/build.gradle
+++ b/allure-report-plugin/src/it/report-only/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    allureReport(files("$buildDir/allure-results"))
+    allureReport(files("$buildDir/manual-allure-results"))
 }
 
 allure {

--- a/allure-report-plugin/src/it/report-only/build/manual-allure-results/simple-result.json
+++ b/allure-report-plugin/src/it/report-only/build/manual-allure-results/simple-result.json
@@ -1,5 +1,5 @@
 {
-  "uuid": "c0417b5d-4905-46d1-8882-560c9936af71",
+  "uuid": "b665386e-b578-463e-a4ce-e3ae1518e203",
   "historyId": "1d9b83988bf21cd8c54ca5f4cf3cedec",
   "fullName": "TestNgTest.testWithAttachment",
   "labels": [],

--- a/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
+++ b/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
@@ -42,6 +42,9 @@ public class ReportOnlyTest {
         BuildResult buildResult = gradleRunner.getBuildResult();
 
         File projectDir = gradleRunner.getProjectDir();
+        File rawResultsDir = new File(projectDir, "build/manual-allure-results");
+        assertThat(rawResultsDir).as("Manually registered Allure results")
+                .isNotEmptyDirectory();
 
         assertThat(buildResult.getTasks())
                 .as("allureReport task should work in projects without sourceSets")

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureServeIntegrationTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureServeIntegrationTest.kt
@@ -54,13 +54,14 @@ class AllureServeIntegrationTest {
             .isEqualTo(TaskOutcome.SUCCESS)
 
         val invocationFile = projectDir.resolve("build/allure/commandline/bin/invocation.txt")
+        val rawResultsDir = projectDir.resolve("build/manual-allure-results")
         assertThat(invocationFile)
             .`as`("Fake allure invocation marker")
             .exists()
         assertThat(invocationFile.readText())
             .`as`("Arguments passed to fake allure")
             .contains("serve")
-            .contains(projectDir.resolve("build/allure-results").canonicalPath)
+            .contains(rawResultsDir.canonicalPath)
     }
 
     private fun createFakeAllureZip(target: File): File {


### PR DESCRIPTION
### Context

Fixes #72.

Adds `allure.adapter.resultsDir` so projects using `io.qameta.allure-adapter` can configure where adapter-managed test tasks write raw Allure results. The default remains `build/allure-results`.

Example:

```kotlin
plugins {
    id("io.qameta.allure-adapter")
    id("io.qameta.allure-report")
}

allure {
    adapter {
        resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))
    }
}
```

When both adapter and report plugins are applied, the custom results directory is published automatically through `allureRawResultElements` and consumed by `allureReport`.

For report-only projects, raw results are still configured explicitly:

```kotlin
plugins {
    id("io.qameta.allure-report")
}

dependencies {
    allureReport(files(layout.buildDirectory.dir("custom-allure-results")))
}
```

Also updates aggregate-report coverage for mixed result sources:
- one module using adapter with a custom results directory
- one module using adapter with the default results directory
- one module manually publishing raw results through `allureRawResultElements`

Tests added/updated for adapter-only, adapter + report, report-only, and aggregate report scenarios.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2