### PR TITLE
Add Allure 3 report support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ plugins {
 }
 
 repositories {
-    // Repository is needed for downloading allure-commandline for building the report
+    // Repository is needed for allure-java adapter dependencies.
+    // The default Allure 3 report runtime is provisioned automatically.
     mavenCentral()
 }
 ```
@@ -41,7 +42,8 @@ plugins {
 }
 
 repositories {
-    // Repository is needed for downloading allure-commandline for building the report
+    // Repository is needed for allure-java adapter dependencies.
+    // The default Allure 3 report runtime is provisioned automatically.
     mavenCentral()
 }
 ```
@@ -55,7 +57,7 @@ Groovy DSL:
 
 ```groovy
 allure {
-    version = "2.38.1"
+    version = "3.4.1"
 }
 ```
 
@@ -63,9 +65,13 @@ Kotlin DSL:
 
 ```kotlin
 allure {
-    version = "2.38.1"
+    version = "3.4.1"
 }
 ```
+
+`allure.version` selects the report runtime family:
+* `3.x` uses the default Allure 3 runtime provisioned by `downloadAllure`
+* `2.x` switches to the Allure 2 `allure-commandline` zip runtime
 
 ### Building Allure report
 
@@ -98,7 +104,7 @@ The sample uses Kotlin DSL. In Groovy DSL you could use `allureJavaVersion = "2.
 
 ```kotlin
 allure {
-    version.set("2.38.1")
+    version.set("3.4.1")
     adapter {
         // Configure version for io.qameta.allure:allure-* adapters
         // It defaults to the latest supported allure-java release
@@ -268,7 +274,7 @@ plugin {
     id("io.qameta.allure-aggregate-report")
 }
 
-// allure-aggregate-report requires allure-commandline, so we need a repository here
+// Add repositories for adapter/test dependencies if the aggregated projects need them.
 repositories {
     mavenCentral()
 }
@@ -333,7 +339,7 @@ allure {
         // Each task creates its own subfolder there
         reportDir.set(project.reporting.baseDirectory.dir("allure-report"))
 
-        // Enable single file generation to open without serving.
+        // Enable single-file report generation.
         singleFile = true
     }
 }
@@ -361,13 +367,16 @@ allure {
 }
 ```
 
-### Customizing allure-commandline download
+### Customizing Allure 2 allure-commandline download
 
 Allure download is handled with `io.qameta.allure-download` plugin which adds `downloadAllure` task.
 Typically, applying `io.qameta.allure-report` is enough, however, you could use `io.qameta.allure-download`
 if you do not need reporting and you need just a fresh `allure-commandline` binary.
 
-By default `allure-commandline` is downloaded from Sonatype OSSRH (also known as Maven Central).
+By default `allure-gradle` provisions Allure 3.
+The Allure 2 `allure-commandline` flow is available only when `allure.version` is set to a `2.x` release.
+
+For `2.x`, `allure-commandline` is downloaded from Sonatype OSSRH (also known as Maven Central).
 
 The plugin receives `allure-commandline` via `io.qameta.allure:allure-commandline:$version@zip` dependency.
 
@@ -375,7 +384,7 @@ If you have a customized version, you could configure it as follows:
 
 ```kotlin
 allure {
-    // This configures the common Allure version, so it is used for commandline as well
+    // Legacy runtime selection.
     version.set("2.38.1")
 
     commandline {
@@ -465,22 +474,30 @@ Configurations:
 
 ### io.qameta.allure-download plugin
 
-Downloads and unpacks `allure-commandline`
+Provisions the selected report runtime into `build/allure/commandline`.
 
 Extensions:
 * `io.qameta.allure.gradle.download.AllureCommandlineExtension`
 
-  `commandline` extension for `allure`
+  `commandline` extension for Allure 2 runtime customization
 
 Configurations:
 * `allureCommandline`
 
-  A configuration to resolve `allure-commandline` zip
+  A configuration to resolve the Allure 2 `allure-commandline` zip
+
+* `allureNodeDistribution`
+
+  Internal configuration used for the provisioned Node.js runtime when `allure.version` is `3.x`
+
+* `allure3Package`
+
+  Optional override for supplying a local Allure 3 package archive in tests or custom setups
 
 Tasks:
 * `downloadAllure: io.qameta.allure.gradle.download.tasks.DownloadAllure`
 
-  Retrieves and unpacks `allure-commandline`
+  Retrieves and assembles the selected report runtime
 
 ### io.qameta.allure-report-base plugin
 

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureExtension.kt
@@ -16,16 +16,20 @@ abstract class AllureExtension(
 ) {
     companion object {
         const val NAME = "allure"
-        const val DEFAULT_VERSION = "2.38.1"
+        const val DEFAULT_VERSION = "3.4.1"
+        const val LAST_ALLURE_2_VERSION = "2.38.1"
     }
 
     /**
-     * `allure-commandline` version
+     * Allure report runtime version.
+     *
+     * `2.x` selects the Allure 2 `allure-commandline` runtime.
+     * `3.x` selects the Allure 3 runtime.
      */
     val version: Property<String> = objects.property<String>().convention(DEFAULT_VERSION)
 
     /**
-     * Default environment variables for launching `allure-commandline`.
+     * Default environment variables for launching Allure runtime commands.
      */
     abstract val environment: MapProperty<String, Any>
 

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureVersion.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/AllureVersion.kt
@@ -1,0 +1,16 @@
+package io.qameta.allure.gradle.base
+
+enum class AllureRuntimeFamily {
+    ALLURE_2,
+    ALLURE_3,
+}
+
+fun String.allureRuntimeFamily(): AllureRuntimeFamily {
+    val major = substringBefore('.').toIntOrNull()
+        ?: throw IllegalArgumentException("Unsupported Allure version: $this")
+    return if (major >= 3) {
+        AllureRuntimeFamily.ALLURE_3
+    } else {
+        AllureRuntimeFamily.ALLURE_2
+    }
+}

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/AllureExecTask.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/AllureExecTask.kt
@@ -1,6 +1,8 @@
 package io.qameta.allure.gradle.base.tasks
 
 import io.qameta.allure.gradle.base.AllureExtension
+import io.qameta.allure.gradle.base.AllureRuntimeFamily
+import io.qameta.allure.gradle.base.allureRuntimeFamily
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
@@ -53,6 +55,9 @@ abstract class AllureExecTask() : Exec() {
     protected val allureExecutable: Provider<File> = allureHome.map {
         defaultAllureExecutable(it.asFile)
     }
+
+    @get:Internal
+    protected val allureVersion = project.the<AllureExtension>().version
 
     // InputDirectories does not exist yet: https://github.com/gradle/gradle/issues/7485#issuecomment-585289792
     @Internal
@@ -107,6 +112,9 @@ abstract class AllureExecTask() : Exec() {
     }
 
     protected fun resolveAllureExecutable(): File = validateAllureExecutable()
+
+    protected fun usesAllure3Runtime(): Boolean =
+        allureVersion.get().allureRuntimeFamily() == AllureRuntimeFamily.ALLURE_3
 
     protected fun resolveEnvironment(): Map<String, String> {
         val resolvedEnvironment = linkedMapOf<String, String>()

--- a/allure-plugin/src/it/categories/build.gradle
+++ b/allure-plugin/src/it/categories/build.gradle
@@ -12,4 +12,5 @@ repositories {
 }
 
 allure {
+    version = '2.38.1'
 }

--- a/allure-plugin/src/it/custom-results-dir/build.gradle
+++ b/allure-plugin/src/it/custom-results-dir/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 }
 
 allure {
+    version = "2.38.1"
     adapter {
         resultsDir = layout.buildDirectory.dir("custom-allure-results")
         // Newer allure-java fails to adapt data from JUnit5 in this fixture.

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -6,7 +6,7 @@ plugins {
 // The folowing tests different syntax variations to verify if they compile
 
 allure {
-    version = "42.0"
+    version = "2.38.1"
     environment["TZ"] = "UTC"
     adapter {
         resultsDir = layout.buildDirectory.dir("custom-allure-results")

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 // The folowing tests different syntax variations to verify if they compile
 
 allure {
-    version.set("42.0")
+    version.set("2.38.1")
     environment.put("TZ", "UTC")
     adapter {
         resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))

--- a/allure-plugin/src/it/junit5-5.8.1/build.gradle
+++ b/allure-plugin/src/it/junit5-5.8.1/build.gradle
@@ -17,5 +17,6 @@ dependencies {
 }
 
 allure {
+    version = "2.38.1"
     adapter.allureJavaVersion = "2.14.0"
 }

--- a/allure-plugin/src/it/report-multi/build.gradle
+++ b/allure-plugin/src/it/report-multi/build.gradle
@@ -15,3 +15,7 @@ dependencies {
 repositories {
     mavenCentral()
 }
+
+allure {
+    version = '2.38.1'
+}

--- a/allure-plugin/src/main/kotlin/io/qameta/allure/gradle/allure/AllurePlugin.kt
+++ b/allure-plugin/src/main/kotlin/io/qameta/allure/gradle/allure/AllurePlugin.kt
@@ -8,7 +8,7 @@ import org.gradle.kotlin.dsl.apply
 
 /**
  * This is a shortcut for [AllureAdapterPlugin.PLUGIN_NAME] and [AllureReportPlugin.PLUGIN_NAME] plugins.
- * If you need an aggregate report, then use [AllureAggregateReportPlugin.PLUGIN_NAME] plugin.
+ * If you need an aggregate report, then use the `io.qameta.allure-aggregate-report` plugin.
  */
 open class AllurePlugin : Plugin<Project> {
     companion object {

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3AggregateReportTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3AggregateReportTest.kt
@@ -1,0 +1,137 @@
+package io.qameta.allure.gradle.report
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume.assumeFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class Allure3AggregateReportTest {
+    @Rule
+    @JvmField
+    val tempDir = TemporaryFolder()
+
+    @Test
+    fun `allureAggregateReport should use Allure 3 by default`() {
+        assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
+
+        val projectDir = tempDir.newFolder("allure3-aggregate")
+        File("src/it/report-multi").copyRecursively(projectDir, overwrite = true)
+
+        val nodeArchive = createFakeNodeArchive(projectDir)
+        val fakePackage = projectDir.resolve("fake-allure.tgz").apply {
+            writeText("fake")
+        }
+
+        projectDir.resolve("build.gradle").writeText(
+            """
+            plugins {
+                id 'io.qameta.allure-aggregate-report'
+            }
+
+            configurations.allureAggregateReport.dependencies.clear()
+            dependencies {
+                allureAggregateReport(project(":module1"))
+                allureAggregateReport(project(":module2"))
+                allureAggregateReport(project(":module3"))
+                allureNodeDistribution(files('${nodeArchive.absolutePath.replace("\\", "/")}'))
+                allure3Package(files('${fakePackage.absolutePath.replace("\\", "/")}'))
+            }
+            """.trimIndent()
+        )
+
+        val buildResult = GradleRunner.create()
+            .withProjectDir(projectDir)
+            .withGradleVersion("9.0.0")
+            .withPluginClasspath()
+            .withTestKitDir(projectDir.resolve(".gradle-testkit"))
+            .withArguments(
+                "--stacktrace",
+                "--info",
+                "-Porg.gradle.daemon=false",
+                "--no-watch-fs",
+                "allureAggregateReport"
+            )
+            .forwardOutput()
+            .build()
+
+        assertThat(buildResult.task(":downloadNode")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":installAllure3")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":allureAggregateReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureAggregateReport/summary.json"))
+            .exists()
+    }
+
+    private fun createFakeNodeArchive(projectDir: File): File {
+        val rootDir = projectDir.resolve("fake-node")
+        val nodeRoot = rootDir.resolve("node-v22.22.0-test")
+        val binDir = nodeRoot.resolve("bin")
+        binDir.mkdirs()
+
+        binDir.resolve("node").writeText(
+            """
+            #!/bin/sh
+            SCRIPT_DIR=${'$'}(CDPATH= cd -- "${'$'}(dirname "${'$'}0")" && pwd)
+            CLI_FILE="${'$'}1"
+            shift
+            COMMAND="${'$'}1"
+            shift
+            if [ "${'$'}COMMAND" = "generate" ]; then
+              CONFIG=""
+              while [ "${'$'}#" -gt 0 ]; do
+                if [ "${'$'}1" = "--config" ]; then
+                  CONFIG="${'$'}2"
+                  break
+                fi
+                shift
+              done
+              OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              mkdir -p "${'$'}OUTPUT"
+              printf '{}' > "${'$'}OUTPUT/summary.json"
+            fi
+            exit 0
+            """.trimIndent() + "\n"
+        )
+        binDir.resolve("npm").writeText(
+            """
+            #!/bin/sh
+            PREFIX=""
+            while [ "${'$'}#" -gt 0 ]; do
+              case "${'$'}1" in
+                --prefix)
+                  PREFIX="${'$'}2"
+                  shift 2
+                  ;;
+                *)
+                  shift
+                  ;;
+              esac
+            done
+            mkdir -p "${'$'}PREFIX/node_modules/allure"
+            printf 'console.log("fake allure");\n' > "${'$'}PREFIX/node_modules/allure/cli.js"
+            """.trimIndent() + "\n"
+        )
+        binDir.resolve("node").setExecutable(true)
+        binDir.resolve("npm").setExecutable(true)
+
+        val archive = projectDir.resolve("fake-node.tar.gz")
+        val process = ProcessBuilder(
+            "tar",
+            "-czf",
+            archive.absolutePath,
+            "-C",
+            rootDir.absolutePath,
+            nodeRoot.name
+        ).inheritIO().start()
+        check(process.waitFor() == 0) { "Failed to create fake Node.js archive" }
+        return archive
+    }
+}
+

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllurePluginFeatureMatrixTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllurePluginFeatureMatrixTest.kt
@@ -1,0 +1,175 @@
+package io.qameta.allure.gradle.report
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class AllurePluginFeatureMatrixTest {
+    @Rule
+    @JvmField
+    val tempDir = TemporaryFolder()
+
+    @Parameterized.Parameter
+    lateinit var runtime: TestAllureRuntime
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun runtimes() = listOf(
+            arrayOf(TestAllureRuntime.ALLURE_2),
+            arrayOf(TestAllureRuntime.ALLURE_3),
+        )
+    }
+
+    @Test
+    fun `categories are copied for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/categories")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+
+        val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("allureReport"))
+            .build()
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(buildResult, runtime)
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/allure-results").listFiles().orEmpty().map { it.name })
+            .filteredOn { it.endsWith("categories.json") }
+            .hasSize(1)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+    }
+
+    @Test
+    fun `custom results dir is reused by report task for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/custom-results-dir")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+
+        val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("test", "allureReport"))
+            .build()
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(buildResult, runtime)
+        assertThat(buildResult.task(":test")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/allure-results"))
+            .doesNotExist()
+        assertThat(projectDir.resolve("build/custom-allure-results"))
+            .isNotEmptyDirectory()
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+    }
+
+    @Test
+    fun `allureReport respects depends-on-tests for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/junit5-5.8.1")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+
+        val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("allureReport", "--depends-on-tests"))
+            .build()
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(buildResult, runtime)
+        assertThat(buildResult.task(":test")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+    }
+
+    @Test
+    fun `allureReport stays no-source without depends-on-tests for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/junit5-5.8.1")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+
+        val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("allureReport"))
+            .build()
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(buildResult, runtime)
+        assertThat(buildResult.task(":test"))
+            .isNull()
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.NO_SOURCE)
+    }
+
+    @Test
+    fun `allureReport reuses results from previous Kotlin DSL test run for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/junit4-kotlin")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+
+        val testResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("test"))
+            .build()
+        assertThat(testResult.task(":test")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/allure-results"))
+            .isNotEmptyDirectory()
+
+        val reportResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("allureReport"))
+            .build()
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(reportResult, runtime)
+        assertThat(reportResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+    }
+
+    @Test
+    fun `full DSL scripts compile for both runtimes`() {
+        listOf("src/it/full-dsl-kotlin", "src/it/full-dsl-groovy").forEach { fixture ->
+            val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, fixture)
+            AllureRuntimeMatrixSupport.configureRuntime(
+                projectDir = projectDir,
+                runtime = runtime,
+                stripLegacyCommandlineDsl = runtime == TestAllureRuntime.ALLURE_3,
+            )
+
+            val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+                .withArguments(AllureRuntimeMatrixSupport.commonArgs("testDsl"))
+                .build()
+
+            assertThat(buildResult.task(":testDsl")?.outcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+        }
+    }
+
+    @Test
+    fun `testng spi-off keeps raw results empty for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/testng-spi-off")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime)
+
+        val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("test"))
+            .build()
+
+        assertThat(buildResult.task(":test")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/allure-results").listFiles().orEmpty())
+            .filteredOn { it.name != "executor.json" }
+            .isEmpty()
+    }
+
+    @Test
+    fun `adapter exposes artifacts for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/expose-artifacts")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime)
+
+        val buildResult = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("testCodeCoverageReport", "--dry-run"))
+            .build()
+
+        assertThat(buildResult.output)
+            .contains("BUILD SUCCESSFUL")
+    }
+}

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureRuntimeMatrixSupport.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureRuntimeMatrixSupport.kt
@@ -1,0 +1,231 @@
+package io.qameta.allure.gradle.report
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assume.assumeFalse
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+enum class TestAllureRuntime(val version: String) {
+    ALLURE_2("2.38.1"),
+    ALLURE_3("3.4.1"),
+}
+
+internal object AllureRuntimeMatrixSupport {
+    fun copyFixture(tempDir: TemporaryFolder, fixturePath: String): File {
+        val fixtureDir = File(fixturePath)
+        require(fixtureDir.isDirectory) { "Fixture $fixturePath does not exist" }
+
+        val projectDir = tempDir.newFolder("${fixtureDir.name}-${System.nanoTime()}")
+        fixtureDir.copyRecursively(projectDir, overwrite = true)
+
+        if (!projectDir.resolve("settings.gradle").exists() && !projectDir.resolve("settings.gradle.kts").exists()) {
+            val settingsFile = if (projectDir.resolve("build.gradle.kts").exists()) {
+                projectDir.resolve("settings.gradle.kts")
+            } else {
+                projectDir.resolve("settings.gradle")
+            }
+            settingsFile.createNewFile()
+        }
+        return projectDir
+    }
+
+    fun configureRuntime(
+        projectDir: File,
+        runtime: TestAllureRuntime,
+        usesReportRuntime: Boolean = false,
+        stripLegacyCommandlineDsl: Boolean = false,
+    ) {
+        val buildFile = findBuildFile(projectDir)
+        if (stripLegacyCommandlineDsl && runtime == TestAllureRuntime.ALLURE_3) {
+            stripLegacyCommandlineDsl(buildFile)
+        }
+        appendSnippet(buildFile, versionOverrideSnippet(buildFile, runtime))
+        if (usesReportRuntime && runtime == TestAllureRuntime.ALLURE_3) {
+            requireAllure3ReportRuntimeSupport()
+            val fakeRuntime = createFakeAllure3Runtime(projectDir)
+            appendSnippet(buildFile, allure3DependenciesSnippet(buildFile, fakeRuntime))
+        }
+    }
+
+    fun runner(projectDir: File, gradleVersion: String = "9.0.0"): GradleRunner = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withGradleVersion(gradleVersion)
+        .withPluginClasspath()
+        .withTestKitDir(projectDir.resolve(".gradle-testkit"))
+        .forwardOutput()
+
+    fun commonArgs(vararg tasks: String): List<String> = listOf(
+        "--stacktrace",
+        "--info",
+        "-Porg.gradle.daemon=false",
+        "--no-watch-fs",
+        *tasks
+    )
+
+    fun assertRuntimeTasks(buildResult: BuildResult, runtime: TestAllureRuntime) {
+        if (runtime == TestAllureRuntime.ALLURE_2) {
+            assertThat(buildResult.task(":downloadAllure")?.outcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(buildResult.task(":downloadNode"))
+                .isNull()
+            assertThat(buildResult.task(":installAllure3"))
+                .isNull()
+        } else {
+            assertThat(buildResult.task(":downloadNode")?.outcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(buildResult.task(":installAllure3")?.outcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(buildResult.task(":downloadAllure")?.outcome)
+                .isEqualTo(TaskOutcome.SUCCESS)
+        }
+    }
+
+    private fun findBuildFile(projectDir: File): File = listOf(
+        projectDir.resolve("build.gradle"),
+        projectDir.resolve("build.gradle.kts"),
+    ).firstOrNull(File::exists)
+        ?: error("No build.gradle or build.gradle.kts found in ${projectDir.absolutePath}")
+
+    private fun appendSnippet(buildFile: File, snippet: String) {
+        buildFile.appendText("\n\n$snippet\n")
+    }
+
+    private fun versionOverrideSnippet(buildFile: File, runtime: TestAllureRuntime): String =
+        if (buildFile.name.endsWith(".kts")) {
+            """
+            allure {
+                version.set("${runtime.version}")
+            }
+            """.trimIndent()
+        } else {
+            """
+            allure {
+                version = '${runtime.version}'
+            }
+            """.trimIndent()
+        }
+
+    private fun stripLegacyCommandlineDsl(buildFile: File) {
+        val text = buildFile.readText()
+        val stripped = text
+            .replace(Regex("""(?ms)\n\s*commandline\s*\{.*?\n\s*\}"""), "")
+            .replace(Regex("""(?m)^\s*commandline\.group.*\n?"""), "")
+            .replace(Regex("""(?m)^\s*allure\.commandline\.downloadUrlPattern.*\n?"""), "")
+        buildFile.writeText(stripped)
+    }
+
+    private fun requireAllure3ReportRuntimeSupport() {
+        assumeFalse(
+            "Fake Allure 3 runtime tests currently support Unix-like systems only",
+            Os.isFamily(Os.FAMILY_WINDOWS)
+        )
+    }
+
+    private fun createFakeAllure3Runtime(projectDir: File): FakeAllure3Runtime {
+        val nodeArchive = createFakeNodeArchive(projectDir)
+        val fakePackage = projectDir.resolve("fake-allure.tgz").apply {
+            writeText("fake")
+        }
+        return FakeAllure3Runtime(nodeArchive, fakePackage)
+    }
+
+    private fun createFakeNodeArchive(projectDir: File): File {
+        val rootDir = projectDir.resolve("fake-node")
+        val nodeRoot = rootDir.resolve("node-v22.22.0-test")
+        val binDir = nodeRoot.resolve("bin")
+        binDir.mkdirs()
+
+        binDir.resolve("node").writeText(
+            """
+            #!/bin/sh
+            SCRIPT_DIR=${'$'}(CDPATH= cd -- "${'$'}(dirname "${'$'}0")" && pwd)
+            LOG_FILE="${'$'}SCRIPT_DIR/../invocations.txt"
+            CLI_FILE="${'$'}1"
+            shift
+            COMMAND="${'$'}1"
+            shift
+            {
+              printf 'cli=%s\n' "${'$'}CLI_FILE"
+              printf 'command=%s\n' "${'$'}COMMAND"
+              printf 'args=%s\n' "${'$'}*"
+            } >> "${'$'}LOG_FILE"
+            if [ "${'$'}COMMAND" = "generate" ]; then
+              CONFIG=""
+              while [ "${'$'}#" -gt 0 ]; do
+                if [ "${'$'}1" = "--config" ]; then
+                  CONFIG="${'$'}2"
+                  break
+                fi
+                shift
+              done
+              OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              mkdir -p "${'$'}OUTPUT"
+              printf '{}' > "${'$'}OUTPUT/summary.json"
+            fi
+            exit 0
+            """.trimIndent() + "\n"
+        )
+        binDir.resolve("npm").writeText(
+            """
+            #!/bin/sh
+            PREFIX=""
+            TARGET=""
+            while [ "${'$'}#" -gt 0 ]; do
+              case "${'$'}1" in
+                --prefix)
+                  PREFIX="${'$'}2"
+                  shift 2
+                  ;;
+                *)
+                  TARGET="${'$'}1"
+                  shift
+                  ;;
+              esac
+            done
+            mkdir -p "${'$'}PREFIX/node_modules/allure"
+            printf '%s\n' "${'$'}TARGET" > "${'$'}PREFIX/install-target.txt"
+            printf 'console.log("fake allure");\n' > "${'$'}PREFIX/node_modules/allure/cli.js"
+            """.trimIndent() + "\n"
+        )
+        binDir.resolve("node").setExecutable(true)
+        binDir.resolve("npm").setExecutable(true)
+
+        val archive = projectDir.resolve("fake-node.tar.gz")
+        val process = ProcessBuilder(
+            "tar",
+            "-czf",
+            archive.absolutePath,
+            "-C",
+            rootDir.absolutePath,
+            nodeRoot.name
+        ).inheritIO().start()
+        check(process.waitFor() == 0) { "Failed to create fake Node.js archive" }
+        return archive
+    }
+
+    private fun allure3DependenciesSnippet(buildFile: File, runtime: FakeAllure3Runtime): String =
+        if (buildFile.name.endsWith(".kts")) {
+            """
+            dependencies {
+                allureNodeDistribution(files("${runtime.nodeArchive.absolutePath.replace("\\", "/")}"))
+                allure3Package(files("${runtime.packageFile.absolutePath.replace("\\", "/")}"))
+            }
+            """.trimIndent()
+        } else {
+            """
+            dependencies {
+                allureNodeDistribution(files('${runtime.nodeArchive.absolutePath.replace("\\", "/")}'))
+                allure3Package(files('${runtime.packageFile.absolutePath.replace("\\", "/")}'))
+            }
+            """.trimIndent()
+        }
+
+    private data class FakeAllure3Runtime(
+        val nodeArchive: File,
+        val packageFile: File,
+    )
+}

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/AllureDownloadPlugin.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/AllureDownloadPlugin.kt
@@ -1,7 +1,10 @@
 package io.qameta.allure.gradle.download
 import io.qameta.allure.gradle.base.AllureBasePlugin
 import io.qameta.allure.gradle.base.AllureExtension
+import io.qameta.allure.gradle.base.AllureRuntimeFamily
 import io.qameta.allure.gradle.download.tasks.DownloadAllure
+import io.qameta.allure.gradle.download.tasks.DownloadNode
+import io.qameta.allure.gradle.download.tasks.InstallAllure3
 import io.qameta.allure.gradle.report.AllureReportBasePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -19,6 +22,10 @@ open class AllureDownloadPlugin : Plugin<Project> {
         const val PLUGIN_NAME = "io.qameta.allure-download"
         const val ALLURE_DOWNLOAD_TASK_NAME = "downloadAllure"
         const val ALLURE_COMMANDLINE_CONFIGURATION = "allureCommandline"
+        const val ALLURE_NODE_CONFIGURATION = "allureNodeDistribution"
+        const val ALLURE_3_PACKAGE_CONFIGURATION = "allure3Package"
+        const val DOWNLOAD_NODE_TASK_NAME = "downloadNode"
+        const val INSTALL_ALLURE_3_TASK_NAME = "installAllure3"
     }
 
     override fun apply(target: Project): Unit = target.run {
@@ -39,6 +46,9 @@ open class AllureDownloadPlugin : Plugin<Project> {
             isCanBeResolved = true
             isCanBeConsumed = false
             defaultDependencies {
+                if (allureRuntimeFamily(allureExtension.version.get()) != AllureRuntimeFamily.ALLURE_2) {
+                    return@defaultDependencies
+                }
                 val fileExtension = reportExtension.extension.map { "@$it" }.orNull ?: ""
                 val group = reportExtension.group.get()
                 val module = reportExtension.module.get()
@@ -52,8 +62,66 @@ open class AllureDownloadPlugin : Plugin<Project> {
             }
         }
 
+        val nodeDistribution = configurations.register(ALLURE_NODE_CONFIGURATION) {
+            isCanBeResolved = true
+            isCanBeConsumed = false
+            defaultDependencies {
+                if (allureRuntimeFamily(allureExtension.version.get()) != AllureRuntimeFamily.ALLURE_3) {
+                    return@defaultDependencies
+                }
+                val nodeDistribution = detectNodeDistribution()
+                val module = "node-${nodeDistribution.classifier}"
+                val nodeVersion = DEFAULT_NODE_VERSION
+                add(
+                    project.dependencies.create(
+                        mapOf(
+                            "group" to "org.nodejs",
+                            "name" to module,
+                            "version" to nodeVersion,
+                            "ext" to nodeDistribution.extension,
+                        )
+                    )
+                )
+                declareCustomAllureCommandlineRepository(
+                    group = "org.nodejs",
+                    module = module,
+                    link = nodeDistributionLink(nodeVersion, nodeDistribution)
+                )
+            }
+        }
+
+        val allure3Package = configurations.register(ALLURE_3_PACKAGE_CONFIGURATION) {
+            isCanBeResolved = true
+            isCanBeConsumed = false
+        }
+
+        val downloadNode = tasks.register<DownloadNode>(DOWNLOAD_NODE_TASK_NAME) {
+            nodeVersion.set(DEFAULT_NODE_VERSION)
+            this.nodeDistribution.from(nodeDistribution)
+        }
+
+        val installAllure3 = tasks.register<InstallAllure3>(INSTALL_ALLURE_3_TASK_NAME) {
+            dependsOn(downloadNode)
+            allureVersion.set(allureExtension.version)
+            nodeHome.set(downloadNode.flatMap { it.destinationDir })
+            allurePackageOverride.from(allure3Package)
+            installEnvironment.putAll(allureExtension.environment)
+        }
+
         tasks.register<DownloadAllure>(ALLURE_DOWNLOAD_TASK_NAME) {
+            allureVersion.set(allureExtension.version)
             this.allureCommandLine.from(allureCommandLine)
+            nodeHome.set(downloadNode.flatMap { it.destinationDir })
+            allure3Home.set(installAllure3.flatMap { it.destinationDir })
+            dependsOn(
+                allureExtension.version.map {
+                    if (allureRuntimeFamily(it) == AllureRuntimeFamily.ALLURE_3) {
+                        listOf(installAllure3)
+                    } else {
+                        emptyList<Any>()
+                    }
+                }
+            )
         }
     }
 
@@ -94,6 +162,9 @@ open class AllureDownloadPlugin : Plugin<Project> {
             }
         }
     }
+
+    private fun nodeDistributionLink(nodeVersion: String, distribution: NodeDistribution): String =
+        "https://nodejs.org/dist/v$nodeVersion/node-v$nodeVersion-${distribution.classifier}.${distribution.extension}"
 
     fun RepositoryHandler.exclusiveRepo(
         group: String,

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/AllureRuntimeSupport.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/AllureRuntimeSupport.kt
@@ -1,0 +1,60 @@
+package io.qameta.allure.gradle.download
+
+import io.qameta.allure.gradle.base.AllureExtension
+import io.qameta.allure.gradle.base.AllureRuntimeFamily
+import io.qameta.allure.gradle.base.allureRuntimeFamily
+import org.gradle.api.plugins.ExtensionAware
+
+internal const val DEFAULT_NODE_VERSION = "22.22.0"
+
+internal data class NodeDistribution(
+    val classifier: String,
+    val extension: String,
+)
+
+internal fun allureRuntimeFamily(version: String) = version.allureRuntimeFamily()
+
+internal fun detectNodeDistribution(
+    osName: String = System.getProperty("os.name"),
+    archName: String = System.getProperty("os.arch"),
+): NodeDistribution {
+    val os = osName.lowercase()
+    val arch = archName.lowercase()
+
+    val normalizedArch = when (arch) {
+        "aarch64", "arm64" -> "arm64"
+        "amd64", "x86_64" -> "x64"
+        else -> throw IllegalArgumentException(
+            "Unsupported architecture for Allure 3 runtime: $archName. " +
+                "Supported architectures: x64, arm64."
+        )
+    }
+
+    return when {
+        os.contains("mac") || os.contains("darwin") ->
+            NodeDistribution("darwin-$normalizedArch", "tar.gz")
+        os.contains("linux") ->
+            NodeDistribution("linux-$normalizedArch", "tar.gz")
+        os.contains("windows") ->
+            NodeDistribution("win-$normalizedArch", "zip")
+        else -> throw IllegalArgumentException(
+            "Unsupported operating system for Allure 3 runtime: $osName. " +
+                "Supported operating systems: macOS, Linux, Windows."
+        )
+    }
+}
+
+internal fun AllureExtension.commandlineExtension(): AllureCommandlineExtension =
+    (this as ExtensionAware).extensions.getByType(AllureCommandlineExtension::class.java)
+
+internal fun AllureExtension.hasAllure2CommandlineCustomization(): Boolean {
+    if (version.get().allureRuntimeFamily() == AllureRuntimeFamily.ALLURE_2) {
+        return false
+    }
+    val commandline = commandlineExtension()
+    val expectedModule = "allure-commandline"
+    return commandline.downloadUrlPattern.orNull != null ||
+        commandline.group.orNull != "io.qameta.allure" ||
+        commandline.module.orNull != expectedModule ||
+        commandline.extension.orNull != "zip"
+}

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/DownloadAllure.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/DownloadAllure.kt
@@ -1,19 +1,30 @@
 package io.qameta.allure.gradle.download.tasks
 
+import io.qameta.allure.gradle.base.AllureExtension
+import io.qameta.allure.gradle.download.AllureDownloadPlugin
+import io.qameta.allure.gradle.download.commandlineExtension
+import io.qameta.allure.gradle.download.hasAllure2CommandlineCustomization
+import io.qameta.allure.gradle.download.allureRuntimeFamily
+import io.qameta.allure.gradle.base.AllureRuntimeFamily
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RelativePath
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.the
+import java.io.File
 import javax.inject.Inject
 
 /**
@@ -35,16 +46,33 @@ abstract class DownloadAllure : DefaultTask() {
     @get:Inject
     abstract val archiveOps: ArchiveOperations
 
+    @Input
+    val allureVersion = objects.property<String>()
+
     @InputFiles
+    @Optional
     @PathSensitive(PathSensitivity.NONE)
     val allureCommandLine: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:org.gradle.api.tasks.Internal
+    abstract val nodeHome: DirectoryProperty
+
+    @get:org.gradle.api.tasks.Internal
+    abstract val allure3Home: DirectoryProperty
 
     @OutputDirectory
     val destinationDir = layout.buildDirectory.dir("allure/commandline")
 
     @TaskAction
     fun downloadAllure() {
-        logger.info("Unpacking Allure Commandline to ${destinationDir.get()}")
+        when (allureRuntimeFamily(allureVersion.get())) {
+            AllureRuntimeFamily.ALLURE_2 -> unpackAllure2()
+            AllureRuntimeFamily.ALLURE_3 -> assembleAllure3()
+        }
+    }
+
+    private fun unpackAllure2() {
+        logger.info("Unpacking Allure 2 runtime to {}", destinationDir.get().asFile)
         val result = fs.sync {
             into(destinationDir)
             from(archiveOps.zipTree(allureCommandLine.singleFile)) {
@@ -56,5 +84,67 @@ abstract class DownloadAllure : DefaultTask() {
             }
         }
         didWork = result.didWork
+    }
+
+    private fun assembleAllure3() {
+        validateAllure3Configuration()
+
+        val destination = destinationDir.get().asFile
+        logger.info("Assembling Allure 3 runtime to {}", destination)
+        val result = fs.sync {
+            into(destination)
+            from(nodeHome) {
+                into("node")
+            }
+            from(allure3Home) {
+                into("package")
+            }
+        }
+        writeLaunchers(destination)
+        didWork = result.didWork || true
+    }
+
+    private fun validateAllure3Configuration() {
+        val allureExtension = project.the<AllureExtension>()
+        val commandline = allureExtension.commandlineExtension()
+        val allureCommandlineConfig = project.configurations.getByName(AllureDownloadPlugin.ALLURE_COMMANDLINE_CONFIGURATION)
+
+        val hasManualAllure2Dependency = allureCommandlineConfig.dependencies.isNotEmpty()
+        if (allureExtension.hasAllure2CommandlineCustomization() || hasManualAllure2Dependency) {
+            val details = buildString {
+                append("Allure 3 does not support Allure 2 allure.commandline or allureCommandline customization. ")
+                append("Set allure.version to a 2.x release to use Allure 2 commandline configuration.")
+                if (commandline.downloadUrlPattern.orNull != null) {
+                    append(" Detected allure.commandline.downloadUrlPattern.")
+                }
+                if (hasManualAllure2Dependency) {
+                    append(" Detected manual allureCommandline dependencies.")
+                }
+            }
+            throw IllegalArgumentException(details)
+        }
+    }
+
+    private fun writeLaunchers(homeDir: File) {
+        val binDir = homeDir.resolve("bin").apply { mkdirs() }
+        val unixLauncher = binDir.resolve("allure")
+        unixLauncher.writeText(
+            """
+            #!/bin/sh
+            SCRIPT_DIR=${'$'}(CDPATH= cd -- "${'$'}(dirname "${'$'}0")" && pwd)
+            exec "${'$'}SCRIPT_DIR/../node/bin/node" "${'$'}SCRIPT_DIR/../package/node_modules/allure/cli.js" "${'$'}@"
+            """.trimIndent() + "\n"
+        )
+        unixLauncher.setExecutable(true)
+
+        val windowsLauncher = binDir.resolve("allure.bat")
+        windowsLauncher.writeText(
+            (
+                """
+                @echo off
+                "%~dp0..\node\node" "%~dp0..\package\node_modules\allure\cli.js" %*
+                """.trimIndent() + "\r\n"
+                )
+        )
     }
 }

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/DownloadNode.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/DownloadNode.kt
@@ -1,0 +1,70 @@
+package io.qameta.allure.gradle.download.tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RelativePath
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
+import java.io.File
+import javax.inject.Inject
+
+@CacheableTask
+abstract class DownloadNode : DefaultTask() {
+    @get:Inject
+    abstract val objects: ObjectFactory
+
+    @get:Inject
+    abstract val layout: ProjectLayout
+
+    @get:Inject
+    abstract val fs: FileSystemOperations
+
+    @get:Inject
+    abstract val archiveOps: ArchiveOperations
+
+    @Input
+    val nodeVersion = objects.property<String>()
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.NONE)
+    val nodeDistribution: ConfigurableFileCollection = objects.fileCollection()
+
+    @OutputDirectory
+    val destinationDir = layout.buildDirectory.dir("allure/node")
+
+    @TaskAction
+    fun downloadNode() {
+        val archive = nodeDistribution.singleFile
+        logger.info("Unpacking Node.js {} to {}", nodeVersion.get(), destinationDir.get().asFile)
+        val result = fs.sync {
+            into(destinationDir)
+            from(archiveTree(archive)) {
+                eachFile {
+                    relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray())
+                }
+                includeEmptyDirs = false
+            }
+        }
+        didWork = result.didWork
+    }
+
+    private fun archiveTree(archive: File) = when {
+        archive.name.endsWith(".zip") -> archiveOps.zipTree(archive)
+        archive.name.endsWith(".tar.gz") || archive.name.endsWith(".tgz") ->
+            project.tarTree(project.resources.gzip(archive))
+        else -> throw IllegalArgumentException(
+            "Unsupported Node.js archive format: ${archive.name}. Supported formats: .zip, .tar.gz, .tgz"
+        )
+    }
+}
+

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/InstallAllure3.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/InstallAllure3.kt
@@ -22,9 +22,11 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
+import org.gradle.work.DisableCachingByDefault
 import java.io.File
 import javax.inject.Inject
 
+@DisableCachingByDefault(because = "Installs Allure 3 packages via npm without a lockfile")
 abstract class InstallAllure3 : DefaultTask() {
     @get:Inject
     abstract val objects: ObjectFactory

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/InstallAllure3.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/download/tasks/InstallAllure3.kt
@@ -1,0 +1,116 @@
+package io.qameta.allure.gradle.download.tasks
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.Property
+import org.gradle.process.ExecOperations
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.mapProperty
+import org.gradle.kotlin.dsl.property
+import java.io.File
+import javax.inject.Inject
+
+abstract class InstallAllure3 : DefaultTask() {
+    @get:Inject
+    abstract val objects: ObjectFactory
+
+    @get:Inject
+    abstract val layout: ProjectLayout
+
+    @get:Inject
+    abstract val fs: FileSystemOperations
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
+    @get:Input
+    abstract val allureVersion: Property<String>
+
+    @get:InputDirectory
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val nodeHome: DirectoryProperty
+
+    @get:Optional
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    val allurePackageOverride: ConfigurableFileCollection = objects.fileCollection()
+
+    @get:Input
+    val installEnvironment: MapProperty<String, Any> = objects.mapProperty<String, Any>()
+
+    @get:OutputDirectory
+    val destinationDir = layout.buildDirectory.dir("allure/allure3")
+
+    @TaskAction
+    fun installAllure3() {
+        val installDir = destinationDir.get().asFile
+        fs.delete {
+            delete(installDir)
+        }
+        installDir.mkdirs()
+
+        installDir.resolve("package.json").writeText(
+            """
+            {
+              "name": "allure-gradle-runtime",
+              "private": true
+            }
+            """.trimIndent()
+        )
+
+        val installTarget = resolveInstallTarget()
+        val npmExecutable = npmExecutable(nodeHome.get().asFile)
+
+        logger.info("Installing Allure {} into {}", allureVersion.get(), installDir)
+        execOperations.exec {
+            executable = npmExecutable.absolutePath
+            args(
+                "--prefix", installDir.absolutePath,
+                "install",
+                "--no-package-lock",
+                "--no-save",
+                "--ignore-scripts",
+                installTarget
+            )
+            environment(resolveEnvironment())
+        }
+    }
+
+    private fun resolveInstallTarget(): String {
+        if (allurePackageOverride.isEmpty) {
+            return "allure@${allureVersion.get()}"
+        }
+        require(allurePackageOverride.files.size == 1) {
+            "allure3Package must resolve to a single archive"
+        }
+        return allurePackageOverride.singleFile.absolutePath
+    }
+
+    private fun npmExecutable(homeDir: File): File = if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        homeDir.resolve("npm.cmd")
+    } else {
+        homeDir.resolve("bin").resolve("npm")
+    }
+
+    private fun resolveEnvironment(): Map<String, String> = installEnvironment.get().mapValues { unwrapProvider(it.value) }
+
+    private fun unwrapProvider(value: Any): String = when (value) {
+        is Provider<*> -> unwrapProvider(value.get())
+        else -> value.toString()
+    }
+}

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/Allure3Config.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/Allure3Config.kt
@@ -1,0 +1,29 @@
+package io.qameta.allure.gradle.report.tasks
+
+import groovy.json.JsonOutput
+import java.io.File
+
+internal fun writeAllure3Config(
+    file: File,
+    outputDir: File,
+    singleFile: Boolean,
+) {
+    file.parentFile.mkdirs()
+    file.writeText(
+        JsonOutput.prettyPrint(
+            JsonOutput.toJson(
+                mapOf(
+                    "output" to outputDir.absolutePath,
+                    "plugins" to mapOf(
+                        "awesome" to mapOf(
+                            "options" to mapOf(
+                                "singleFile" to singleFile
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+}
+

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureReport.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureReport.kt
@@ -4,6 +4,7 @@ import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.base.tasks.AllureExecTask
 import io.qameta.allure.gradle.base.tasks.ConditionalArgumentProvider
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.options.Option
@@ -38,6 +39,11 @@ abstract class AllureReport : AllureExecTask() {
         project.the<AllureExtension>().report.singleFile
     )
 
+    @get:Internal
+    val allure3ConfigFile = layout.file(
+        providers.provider { temporaryDir.resolve("allurerc.json") }
+    )
+
     companion object {
         const val NAME = "allureReport"
         const val GENERATE_COMMAND = "generate"
@@ -55,16 +61,35 @@ abstract class AllureReport : AllureExecTask() {
                 val rawResults = rawResults.get().map { it.absolutePath }
                 logger.info("Input directories for $name: $rawResults")
                 args.addAll(rawResults)
-                args += "-o"
-                args += reportDir.get().asFile.absolutePath
-                if (clean.get()) {
-                    args += "--clean"
-                }
-                if (singleFile.get()) {
-                    args += "--single-file"
+                if (usesAllure3Runtime()) {
+                    args += "--config"
+                    args += allure3ConfigFile.get().asFile.absolutePath
+                } else {
+                    args += "-o"
+                    args += reportDir.get().asFile.absolutePath
+                    if (clean.get()) {
+                        args += "--clean"
+                    }
+                    if (singleFile.get()) {
+                        args += "--single-file"
+                    }
                 }
                 args
             }
         )
+    }
+
+    override fun exec() {
+        if (usesAllure3Runtime()) {
+            if (clean.get()) {
+                project.delete(reportDir.get().asFile)
+            }
+            writeAllure3Config(
+                file = allure3ConfigFile.get().asFile,
+                outputDir = reportDir.get().asFile,
+                singleFile = singleFile.get()
+            )
+        }
+        super.exec()
     }
 }

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureServe.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureServe.kt
@@ -3,20 +3,32 @@ package io.qameta.allure.gradle.report.tasks
 import io.qameta.allure.gradle.base.tasks.AllureExecTask
 import io.qameta.allure.gradle.base.tasks.ConditionalArgumentProvider
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
+import org.gradle.kotlin.dsl.the
+import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
+import report
 import java.io.InputStream
 import java.io.PrintStream
 import java.lang.management.ManagementFactory
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 @DisableCachingByDefault(because = "Not worth caching")
 abstract class AllureServe : AllureExecTask() {
+    @get:Inject
+    abstract val layout: ProjectLayout
+
+    @get:Inject
+    abstract val execOperations: ExecOperations
+
     companion object {
         const val NAME = "allureServe"
         const val SERVE_COMMAND = "serve"
+        const val OPEN_COMMAND = "open"
     }
 
     init {
@@ -29,6 +41,18 @@ abstract class AllureServe : AllureExecTask() {
 
     @Internal
     val port = objects.property<Int>()
+
+    @get:Internal
+    val allure3ReportDir = objects.directoryProperty().convention(
+        project.the<io.qameta.allure.gradle.base.AllureExtension>().report.reportDir.map {
+            it.dir(this@AllureServe.name)
+        }
+    )
+
+    @get:Internal
+    val allure3ConfigFile = layout.file(
+        providers.provider { temporaryDir.resolve("allurerc.json") }
+    )
 
     @Option(option = "port", description = "This port will be used to start web server for the report")
     fun setPort(port: String) {
@@ -61,6 +85,10 @@ abstract class AllureServe : AllureExecTask() {
     }
 
     override fun exec() {
+        if (usesAllure3Runtime()) {
+            execAllure3()
+            return
+        }
         if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
             super.exec()
             return
@@ -70,6 +98,62 @@ abstract class AllureServe : AllureExecTask() {
             allureArgs = (args?.toMutableList() ?: mutableListOf<String>()) +
                 argumentProviders.flatMap { it.asArguments() },
             environment = resolveEnvironment()
+        )
+    }
+
+    private fun execAllure3() {
+        require(!host.isPresent) {
+            "--host is not supported for Allure 3. Use --port only or set allure.version to a 2.x release."
+        }
+
+        val allureExecutablePath = resolveAllureExecutable().absolutePath
+        val resolvedEnvironment = resolveEnvironment()
+        val configFile = allure3ConfigFile.get().asFile
+        val reportDir = allure3ReportDir.get().asFile
+
+        writeAllure3Config(
+            file = configFile,
+            outputDir = reportDir,
+            singleFile = false
+        )
+
+        val generateArgs = mutableListOf<String>().apply {
+            add("generate")
+            addAll(rawResults.get().map { it.absolutePath })
+            add("--config")
+            add(configFile.absolutePath)
+        }
+
+        execOperations.exec {
+            executable = allureExecutablePath
+            args(generateArgs)
+            environment(resolvedEnvironment)
+        }
+
+        val openArgs = mutableListOf<String>().apply {
+            add(OPEN_COMMAND)
+            add(reportDir.absolutePath)
+            add("--config")
+            add(configFile.absolutePath)
+            port.orNull?.let {
+                add("--port")
+                add(it.toString())
+            }
+        }
+
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            execOperations.exec {
+                executable = allureExecutablePath
+                args(openArgs)
+                environment(resolvedEnvironment)
+            }
+            return
+        }
+
+        startWithProcessBuilder(
+            allureExecutable = allureExecutablePath,
+            allureArgs = openArgs,
+            environment = resolvedEnvironment
         )
     }
 

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/download/DownloadTaskTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/download/DownloadTaskTest.kt
@@ -10,7 +10,17 @@ import org.junit.Test
 
 class DownloadTaskTest {
     @Test
-    fun `basic download`() {
+    fun `default version should target Allure 3`() {
+        ProjectBuilder.builder().build().run {
+            apply(plugin = "io.qameta.allure-report")
+            assertThat(the<AllureExtension>().version.get())
+                .`as`("default Allure runtime version")
+                .isEqualTo(AllureExtension.DEFAULT_VERSION)
+        }
+    }
+
+    @Test
+    fun `basic Allure 2 download`() {
         ProjectBuilder.builder().build().run {
             apply(plugin = "io.qameta.allure-download")
             val allureCommandline by configurations
@@ -18,6 +28,10 @@ class DownloadTaskTest {
             // Repository is required to download allure-commandline
             repositories {
                 mavenCentral()
+            }
+
+            configure<AllureExtension> {
+                version.set(AllureExtension.LAST_ALLURE_2_VERSION)
             }
 
             assertThat(allureCommandline.singleFile).`as`("allure-commandline binary")
@@ -34,7 +48,7 @@ class DownloadTaskTest {
             val customUrl = "https://download-test-[group].test/[module]-custom-[version].zip"
 
             configure<AllureExtension> {
-                version.set("42.0")
+                version.set("2.42.0")
                 // sam-with-receiver does not work in IDEA :(
                 commandline.apply {
                     // .test is reserved, see https://tools.ietf.org/html/rfc2606#section-2
@@ -45,7 +59,7 @@ class DownloadTaskTest {
             assertThatThrownBy {
                 allureCommandline.singleFile
             }.`as`("Custom URL configured as %s", customUrl)
-                .hasStackTraceContaining("https://download-test-custom.io.qameta.allure.test/allure-commandline-custom-42.0.zip")
+                .hasStackTraceContaining("https://download-test-custom.io.qameta.allure.test/allure-commandline-custom-2.42.0.zip")
         }
     }
 
@@ -59,7 +73,7 @@ class DownloadTaskTest {
             val customUrl = "https://localhost/[illegal-for-test].zip"
 
             configure<AllureExtension> {
-                version.set("42.0")
+                version.set("2.42.0")
                 // sam-with-receiver does not work in IDEA :(
                 commandline.apply {
                     downloadUrlPattern.set("https://localhost/[illegal-for-test].zip")
@@ -75,7 +89,7 @@ class DownloadTaskTest {
                             "[organization] = custom.io.qameta.allure, " +
                             "[group] = custom.io.qameta.allure, " +
                             "[module] = allure-commandline, " +
-                            "[version] = 42.0"
+                            "[version] = 2.42.0"
                 )
         }
     }

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
@@ -1,0 +1,245 @@
+package io.qameta.allure.gradle.report
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.testkit.runner.UnexpectedBuildFailure
+import org.junit.Assume.assumeFalse
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class Allure3ReportIntegrationTest {
+    @Rule
+    @JvmField
+    val tempDir = TemporaryFolder()
+
+    @Test
+    fun `allureReport should use Allure 3 by default`() {
+        assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
+
+        val projectDir = createAllure3Project(singleFile = true)
+
+        val buildResult = runner(projectDir)
+            .withArguments(commonArgs("allureReport"))
+            .build()
+
+        assertThat(buildResult.task(":downloadNode")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":installAllure3")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":downloadAllure")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val configFile = projectDir.resolve("build/tmp/allureReport/allurerc.json")
+        assertThat(configFile)
+            .exists()
+        assertThat(configFile.readText())
+            .contains("\"singleFile\": true")
+
+        val reportDir = projectDir.resolve("build/reports/allure-report/allureReport")
+        assertThat(reportDir.resolve("summary.json"))
+            .exists()
+
+        val invocations = projectDir.resolve("build/allure/commandline/node/invocations.txt").readText()
+        assertThat(invocations)
+            .contains("command=generate")
+            .contains("cli=")
+    }
+
+    @Test
+    fun `allureServe should run open for Allure 3`() {
+        assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
+
+        val projectDir = createAllure3Project(singleFile = false)
+
+        val buildResult = runner(projectDir)
+            .withArguments(commonArgs("allureServe", "--port", "4567"))
+            .build()
+
+        assertThat(buildResult.task(":allureServe")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val invocations = projectDir.resolve("build/allure/commandline/node/invocations.txt").readText()
+        assertThat(invocations)
+            .contains("command=generate")
+            .contains("command=open")
+            .contains("--port 4567")
+    }
+
+    @Test
+    fun `allureServe should reject host for Allure 3`() {
+        assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
+
+        val projectDir = createAllure3Project(singleFile = false)
+
+        val failure = runCatching {
+            runner(projectDir).withArguments(commonArgs("allureServe", "--host", "127.0.0.1")).build()
+        }.exceptionOrNull() as? UnexpectedBuildFailure
+
+        val buildFailure = requireNotNull(failure)
+        assertThat(buildFailure)
+            .isNotNull
+        assertThat(buildFailure.message)
+            .contains("--host is not supported for Allure 3")
+    }
+
+    @Test
+    fun `Allure 2 commandline customization should fail for Allure 3`() {
+        assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
+
+        val projectDir = createAllure3Project(
+            singleFile = false,
+            extraAllureBlock = """
+                commandline {
+                    downloadUrlPattern = "https://example.test/allure.zip"
+                }
+            """.trimIndent()
+        )
+
+        val failure = runCatching {
+            runner(projectDir).withArguments(commonArgs("downloadAllure")).build()
+        }.exceptionOrNull() as? UnexpectedBuildFailure
+
+        val buildFailure = requireNotNull(failure)
+        assertThat(buildFailure)
+            .isNotNull
+        assertThat(buildFailure.message)
+            .contains("Allure 3 does not support Allure 2 allure.commandline")
+    }
+
+    private fun createAllure3Project(singleFile: Boolean, extraAllureBlock: String = ""): File {
+        val projectDir = tempDir.newFolder("allure3-project-${System.nanoTime()}")
+        projectDir.resolve("settings.gradle").createNewFile()
+
+        createManualResults(projectDir)
+        val nodeArchive = createFakeNodeArchive(projectDir)
+        val fakePackage = projectDir.resolve("fake-allure.tgz").apply {
+            writeText("fake")
+        }
+
+        projectDir.resolve("build.gradle").writeText(
+            """
+            plugins {
+                id 'io.qameta.allure-report'
+            }
+
+            dependencies {
+                allureReport(files("${'$'}buildDir/manual-allure-results"))
+                allureNodeDistribution(files('${nodeArchive.absolutePath.replace("\\", "/")}'))
+                allure3Package(files('${fakePackage.absolutePath.replace("\\", "/")}'))
+            }
+
+            allure {
+                report {
+                    singleFile = ${if (singleFile) "true" else "false"}
+                }
+                $extraAllureBlock
+            }
+            """.trimIndent()
+        )
+        return projectDir
+    }
+
+    private fun createManualResults(projectDir: File) {
+        val resultsDir = projectDir.resolve("build/manual-allure-results")
+        resultsDir.mkdirs()
+        resultsDir.resolve("simple-result.json").writeText("{}")
+    }
+
+    private fun createFakeNodeArchive(projectDir: File): File {
+        val rootDir = projectDir.resolve("fake-node")
+        val nodeRoot = rootDir.resolve("node-v22.22.0-test")
+        val binDir = nodeRoot.resolve("bin")
+        binDir.mkdirs()
+
+        binDir.resolve("node").writeText(
+            """
+            #!/bin/sh
+            SCRIPT_DIR=${'$'}(CDPATH= cd -- "${'$'}(dirname "${'$'}0")" && pwd)
+            LOG_FILE="${'$'}SCRIPT_DIR/../invocations.txt"
+            CLI_FILE="${'$'}1"
+            shift
+            COMMAND="${'$'}1"
+            shift
+            {
+              printf 'cli=%s\n' "${'$'}CLI_FILE"
+              printf 'command=%s\n' "${'$'}COMMAND"
+              printf 'args=%s\n' "${'$'}*"
+            } >> "${'$'}LOG_FILE"
+            if [ "${'$'}COMMAND" = "generate" ]; then
+              CONFIG=""
+              while [ "${'$'}#" -gt 0 ]; do
+                if [ "${'$'}1" = "--config" ]; then
+                  CONFIG="${'$'}2"
+                  break
+                fi
+                shift
+              done
+              OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              mkdir -p "${'$'}OUTPUT"
+              printf '{}' > "${'$'}OUTPUT/summary.json"
+            fi
+            exit 0
+            """.trimIndent() + "\n"
+        )
+        binDir.resolve("npm").writeText(
+            """
+            #!/bin/sh
+            PREFIX=""
+            TARGET=""
+            while [ "${'$'}#" -gt 0 ]; do
+              case "${'$'}1" in
+                --prefix)
+                  PREFIX="${'$'}2"
+                  shift 2
+                  ;;
+                *)
+                  TARGET="${'$'}1"
+                  shift
+                  ;;
+              esac
+            done
+            mkdir -p "${'$'}PREFIX/node_modules/allure"
+            printf '%s\n' "${'$'}TARGET" > "${'$'}PREFIX/install-target.txt"
+            printf 'console.log("fake allure");\n' > "${'$'}PREFIX/node_modules/allure/cli.js"
+            """.trimIndent() + "\n"
+        )
+        binDir.resolve("node").setExecutable(true)
+        binDir.resolve("npm").setExecutable(true)
+
+        val archive = projectDir.resolve("fake-node.tar.gz")
+        val process = ProcessBuilder(
+            "tar",
+            "-czf",
+            archive.absolutePath,
+            "-C",
+            rootDir.absolutePath,
+            nodeRoot.name
+        ).inheritIO().start()
+        check(process.waitFor() == 0) { "Failed to create fake Node.js archive" }
+        return archive
+    }
+
+    private fun runner(projectDir: File): GradleRunner = GradleRunner.create()
+        .withProjectDir(projectDir)
+        .withGradleVersion("9.0.0")
+        .withPluginClasspath()
+        .withTestKitDir(projectDir.resolve(".gradle-testkit"))
+        .forwardOutput()
+
+    private fun commonArgs(vararg tasks: String) = listOf(
+        "--stacktrace",
+        "--info",
+        "-Porg.gradle.daemon=false",
+        "--no-watch-fs",
+        *tasks
+    )
+}


### PR DESCRIPTION
This PR adds Allure 3 support to the Gradle plugins and makes it the default for report generation. Existing report tasks stay the same, so users still run the same Gradle commands, but new installs now get Allure 3 out of the box.

The change keeps Allure 2 available for projects that still depend on it. Users can stay on Allure 2 by setting `allure.version` to a `2.x` release. That means current setups are still supported, while the default path moves forward to Allure 3.

This PR also expands test coverage so the main plugin features are exercised on both Allure 2 and Allure 3, including report generation, aggregate reports, custom results directories, and common DSL configurations.

**Examples**

Default / Allure 3:
```kotlin
allure {
    version.set("3.4.1")
}
```

Stay on Allure 2:
```kotlin
allure {
    version.set("2.38.1")
}
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2