### PR TITLE
Allow single-file Allure reports from the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,8 @@ allure {
 }
 ```
 
+To enable it for a single invocation without changing the DSL, run `./gradlew allureReport --single-file=true`.
+
 ### Running tests before building the report
 
 By default, `allureReport` task will NOT execute tests.

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureReport.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureReport.kt
@@ -39,6 +39,13 @@ abstract class AllureReport : AllureExecTask() {
         project.the<AllureExtension>().report.singleFile
     )
 
+    @Option(option = "single-file", description = "Generate a single-file Allure report")
+    fun setSingleFile(enabled: String) {
+        val parsed = enabled.toBooleanStrictOrNull()
+            ?: throw IllegalArgumentException("single-file expects true or false, got '$enabled'")
+        singleFile.set(parsed)
+    }
+
     @get:Internal
     val allure3ConfigFile = layout.file(
         providers.provider { temporaryDir.resolve("allurerc.json") }

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
@@ -55,6 +55,26 @@ class Allure3ReportIntegrationTest {
     }
 
     @Test
+    fun `allureReport should accept single-file as a task option`() {
+        assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
+
+        val projectDir = createAllure3Project(singleFile = false)
+
+        val buildResult = runner(projectDir)
+            .withArguments(commonArgs("allureReport", "--single-file=true"))
+            .build()
+
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val configFile = projectDir.resolve("build/tmp/allureReport/allurerc.json")
+        assertThat(configFile)
+            .exists()
+        assertThat(configFile.readText())
+            .contains("\"singleFile\": true")
+    }
+
+    @Test
     fun `allureServe should run open for Allure 3`() {
         assumeFalse("Fake Allure 3 runtime tests currently support Unix-like systems only", Os.isFamily(Os.FAMILY_WINDOWS))
 


### PR DESCRIPTION
### Context

This fixes `allureReport` so single-file report generation can be enabled directly from the command line.

Before this change, running:

./gradlew allureReport --single-file=true

failed during Gradle task configuration.

After this change, the command works as expected and generates a single-file report for that run.

This is useful when you want a single HTML report without changing your build script or committing configuration changes.

You can now choose either approach:

- Configure it in the build script with `allure.report.singleFile = true`
- Enable it for one run with `./gradlew allureReport --single-file=true`

Fixes  #118

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2