### PR TITLE
Fix repeated allureReport/allureServe runs with categories.json in test resources

### DIFF
--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/tasks/CopyCategories.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/tasks/CopyCategories.kt
@@ -38,7 +38,7 @@ abstract class CopyCategories : DefaultTask() {
         set.map { it.resolve("categories.json") }
     }
 
-    @OutputFile
+    @OutputDirectory
     val markerFile = objects.directoryProperty()
         .convention(layout.buildDirectory.dir("copy-categories/$name"))
 

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllurePluginFeatureMatrixTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllurePluginFeatureMatrixTest.kt
@@ -46,6 +46,37 @@ class AllurePluginFeatureMatrixTest {
     }
 
     @Test
+    fun `allureReport can run twice with categories for both runtimes`() {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/categories")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+
+        val firstRun = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("allureReport"))
+            .build()
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(firstRun, runtime)
+        assertThat(firstRun.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/allure-results").listFiles().orEmpty().map { it.name })
+            .filteredOn { it.endsWith("categories.json") }
+            .hasSize(1)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+
+        val secondRun = AllureRuntimeMatrixSupport.runner(projectDir)
+            .withArguments(AllureRuntimeMatrixSupport.commonArgs("allureReport"))
+            .build()
+
+        assertThat(secondRun.task(":allureReport")?.outcome)
+            .isIn(TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE)
+        assertThat(projectDir.resolve("build/allure-results").listFiles().orEmpty().map { it.name })
+            .filteredOn { it.endsWith("categories.json") }
+            .hasSize(1)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+    }
+
+    @Test
     fun `custom results dir is reused by report task for both runtimes`() {
         val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/custom-results-dir")
         AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)


### PR DESCRIPTION
### Context

This fixes a failure when categories.json is stored under test resources and allureReport or allureServe is run more than once.

Fixes #105

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2