### PR TITLE
Fix aspectjWeaver=false being ignored by the adapter plugin

### DIFF
--- a/allure-adapter-plugin/src/it/adapter-aspectj-weaver-disabled-kts/build.gradle.kts
+++ b/allure-adapter-plugin/src/it/adapter-aspectj-weaver-disabled-kts/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("java")
+    id("io.qameta.allure-adapter")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+allure {
+    adapter {
+        aspectjWeaver.set(false)
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+    doFirst {
+        val jvmArgsFile = layout.buildDirectory.file("jvmArgs.txt").get().asFile
+        jvmArgsFile.parentFile.mkdirs()
+        jvmArgsFile.writeText(allJvmArgs.joinToString(System.lineSeparator()))
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-aspectj-weaver-disabled-kts/src/test/java/tests/SimpleTest.java
+++ b/allure-adapter-plugin/src/it/adapter-aspectj-weaver-disabled-kts/src/test/java/tests/SimpleTest.java
@@ -1,0 +1,10 @@
+package tests;
+
+import org.junit.jupiter.api.Test;
+
+class SimpleTest {
+
+    @Test
+    void shouldPass() {
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-aspectj-weaver-enabled-kts/build.gradle.kts
+++ b/allure-adapter-plugin/src/it/adapter-aspectj-weaver-enabled-kts/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    id("java")
+    id("io.qameta.allure-adapter")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+allure {
+    adapter {
+        aspectjWeaver.set(true)
+    }
+}
+
+tasks.test {
+    useJUnitPlatform()
+    doFirst {
+        val jvmArgsFile = layout.buildDirectory.file("jvmArgs.txt").get().asFile
+        jvmArgsFile.parentFile.mkdirs()
+        jvmArgsFile.writeText(allJvmArgs.joinToString(System.lineSeparator()))
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-aspectj-weaver-enabled-kts/src/test/java/tests/SimpleTest.java
+++ b/allure-adapter-plugin/src/it/adapter-aspectj-weaver-enabled-kts/src/test/java/tests/SimpleTest.java
@@ -1,0 +1,10 @@
+package tests;
+
+import org.junit.jupiter.api.Test;
+
+class SimpleTest {
+
+    @Test
+    void shouldPass() {
+    }
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -101,9 +101,9 @@ open class AllureAdapterExtension @Inject constructor(
     }
 
     fun addAspectjTo(task: Task): Unit = task.run {
-        if (aspectjWeaver.get() && this is JavaForkOptions) {
+        if (this is JavaForkOptions) {
             val aspectJAgent = project.configurations[AllureAdapterPlugin.ASPECTJ_WEAVER_CONFIGURATION]
-            jvmArgumentProviders.add(JavaAgentArgumentProvider(aspectJAgent))
+            jvmArgumentProviders.add(JavaAgentArgumentProvider(aspectjWeaver, aspectJAgent))
         }
     }
 

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AspectjWeaverJvmArgsTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AspectjWeaverJvmArgsTest.kt
@@ -1,0 +1,74 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class AspectjWeaverJvmArgsTest {
+    @Rule
+    @JvmField
+    val gradleRunner = GradleRunnerRule()
+        .version { version }
+        .project { project }
+        .tasks("test")
+
+    @Parameterized.Parameter(0)
+    lateinit var version: String
+
+    @Parameterized.Parameter(1)
+    lateinit var project: String
+
+    @Parameterized.Parameter(2)
+    @JvmField
+    var expectedJavaAgent: Boolean = false
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{1} [{0}]")
+        fun data() = listOf<Array<Any>>(
+            arrayOf("9.0.0", "src/it/adapter-aspectj-weaver-disabled-kts", false),
+            arrayOf("8.14.3", "src/it/adapter-aspectj-weaver-disabled-kts", false),
+            arrayOf("8.11.1", "src/it/adapter-aspectj-weaver-disabled-kts", false),
+            arrayOf("9.0.0", "src/it/adapter-aspectj-weaver-enabled-kts", true),
+            arrayOf("8.14.3", "src/it/adapter-aspectj-weaver-enabled-kts", true),
+            arrayOf("8.11.1", "src/it/adapter-aspectj-weaver-enabled-kts", true)
+        )
+    }
+
+    @Test
+    fun `aspectj weaver flag controls javaagent wiring`() {
+        assertThat(gradleRunner.buildResult.task(":test")?.outcome)
+            .`as`("test task outcome")
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val jvmArgs = gradleRunner.projectDir.resolve("build/jvmArgs.txt")
+        assertThat(jvmArgs)
+            .`as`("captured JVM args")
+            .exists()
+
+        val argsText = jvmArgs.readText()
+        if (expectedJavaAgent) {
+            assertThat(argsText)
+                .`as`("AspectJ javaagent")
+                .contains("-javaagent:")
+        } else {
+            assertThat(argsText)
+                .`as`("AspectJ javaagent")
+                .doesNotContain("-javaagent:")
+        }
+
+        val resultsDir = gradleRunner.projectDir.resolve("build/allure-results")
+        assertThat(resultsDir)
+            .`as`("Allure results directory")
+            .isNotEmptyDirectory()
+        assertThat(resultsDir.listFiles())
+            .`as`("Allure results test cases")
+            .filteredOn { file -> file.name.endsWith("result.json") }
+            .hasSize(1)
+    }
+}

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CacheabilityTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CacheabilityTest.kt
@@ -42,7 +42,7 @@ class CacheabilityTest {
         // Enable local build cache in settings.gradle written to the prepared projectDir
         val projectDir = gradleRunner.projectDir
         val testKitHome = projectDir.parentFile.resolve(".gradle")
-        val cacheDir = testKitHome.resolve("build-cache").absoluteFile
+        val cacheDir = projectDir.resolve(".gradle-test-build-cache").absoluteFile
         val settings = File(projectDir, "settings.gradle.kts")
         settings.writeText(
             """
@@ -57,7 +57,7 @@ class CacheabilityTest {
 
         // First run already executed by rule (test task)
         assertThat(gradleRunner.buildResult.task(":test")?.outcome)
-            .isIn(TaskOutcome.SUCCESS, TaskOutcome.NO_SOURCE)
+            .isIn(TaskOutcome.SUCCESS, TaskOutcome.NO_SOURCE, TaskOutcome.FROM_CACHE)
 
         // Delete build dir and run again with build cache
         File(projectDir, "build").deleteRecursively()

--- a/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/JavaAgentArgumentProvider.kt
+++ b/allure-base-plugin/src/main/kotlin/io/qameta/allure/gradle/base/tasks/JavaAgentArgumentProvider.kt
@@ -1,12 +1,22 @@
 package io.qameta.allure.gradle.base.tasks
 
 import org.gradle.api.file.FileCollection
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
 import org.gradle.process.CommandLineArgumentProvider
 
-class JavaAgentArgumentProvider(classPath: FileCollection) : CommandLineArgumentProvider {
+class JavaAgentArgumentProvider(
+    @get:Input
+    val enabled: Provider<Boolean>,
+    classPath: FileCollection
+) : CommandLineArgumentProvider {
     @get:Classpath
     val agentJar: FileCollection = classPath
 
-    override fun asArguments() = listOf("-javaagent:${agentJar.singleFile}")
+    override fun asArguments() = if (enabled.get()) {
+        listOf("-javaagent:${agentJar.singleFile}")
+    } else {
+        emptyList()
+    }
 }


### PR DESCRIPTION
### Context

Fixes #109

Users who disabled the AspectJ weaver with:

```kotlin
allure {
    adapter {
        aspectjWeaver.set(false)
    }
}
```

could still end up with the AspectJ javaagent on test JVMs. That made the opt-out ineffective and could break builds that combine Allure with tools like JaCoCo or frameworks that are sensitive to extra weaving.

This change makes the plugin honor the final aspectjWeaver value when the JVM arguments are built

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2