### PR TITLE
Fix custom Test tasks failing with shared Allure results directory

### DIFF
--- a/allure-adapter-plugin/src/it/adapter-multiple-test-tasks-shared-results-dir/build.gradle.kts
+++ b/allure-adapter-plugin/src/it/adapter-multiple-test-tasks-shared-results-dir/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    id("java")
+    id("io.qameta.allure-adapter")
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation(platform("org.junit:junit-bom:5.10.2"))
+    testImplementation("org.junit.jupiter:junit-jupiter")
+}
+
+val integrationTestSourceSet = sourceSets.create("integrationTest") {
+    java.srcDir("src/integrationTest/java")
+    compileClasspath += sourceSets.main.get().output + configurations.testRuntimeClasspath.get()
+    runtimeClasspath += output + compileClasspath
+}
+
+configurations[integrationTestSourceSet.implementationConfigurationName].extendsFrom(configurations.testImplementation.get())
+configurations[integrationTestSourceSet.runtimeOnlyConfigurationName].extendsFrom(configurations.testRuntimeOnly.get())
+
+tasks.withType<Test>().all {
+    useJUnitPlatform()
+}
+
+tasks.register<Test>("integrationTest") {
+    description = "Runs integration tests."
+    group = "verification"
+    testClassesDirs = integrationTestSourceSet.output.classesDirs
+    classpath = integrationTestSourceSet.runtimeClasspath
+    shouldRunAfter(tasks.test)
+}

--- a/allure-adapter-plugin/src/it/adapter-multiple-test-tasks-shared-results-dir/src/integrationTest/java/tests/IntegrationTest.java
+++ b/allure-adapter-plugin/src/it/adapter-multiple-test-tasks-shared-results-dir/src/integrationTest/java/tests/IntegrationTest.java
@@ -1,0 +1,12 @@
+package tests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class IntegrationTest {
+    @Test
+    void passes() {
+        assertTrue(true);
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-multiple-test-tasks-shared-results-dir/src/test/java/tests/SimpleTest.java
+++ b/allure-adapter-plugin/src/it/adapter-multiple-test-tasks-shared-results-dir/src/test/java/tests/SimpleTest.java
@@ -1,0 +1,12 @@
+package tests;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SimpleTest {
+    @Test
+    void passes() {
+        assertTrue(true);
+    }
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -133,13 +133,17 @@ open class AllureAdapterExtension @Inject constructor(
     // TODO: move to [AllureAdapterBasePlugin] like `allure { gatherResults { fromTask(..) } }
     private fun internalGatherResultsFrom(task: Task) {
         task.run {
+            // Use a detached provider per task so Gradle does not attach the extension property
+            // itself as the output producer for every realized Test task.
+            val taskResultsDir = project.provider { resultsDir.get() }
+
             // Declare the whole results directory as an output to make it cacheable by Gradle.
             // Using a FileTree here makes the task output non-cacheable. See issue #107.
-            outputs.dir(resultsDir)
+            outputs.dir(taskResultsDir)
 
             // Pass the path to the task
             if (this is JavaForkOptions) {
-                jvmArgumentProviders += AllureResultsDirectoryArgumentProvider(resultsDir)
+                jvmArgumentProviders += AllureResultsDirectoryArgumentProvider(taskResultsDir)
                 // We don't know if the task will execute JUnit5 engine or not,
                 // so we add extensions.autodetection.enabled to all the tasks if
                 // junit5.autoconfigureListeners is enabled
@@ -165,7 +169,7 @@ open class AllureAdapterExtension @Inject constructor(
 
             doFirst(
                 GenerateExecutorInfoAction(
-                    resultsDir = resultsDir,
+                    resultsDir = taskResultsDir,
                     taskName = currentTaskName,
                     buildName = buildName,
                     projectPath = projectPath,

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/MultipleTestTasksSharedResultsDirTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/MultipleTestTasksSharedResultsDirTest.kt
@@ -1,0 +1,46 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.File
+
+class MultipleTestTasksSharedResultsDirTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    companion object {
+        @JvmStatic
+        fun versions() = listOf("9.4.1", "8.14.3", "8.11.1")
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("versions")
+    fun `multiple realized test tasks can share the adapter results directory`(version: String) {
+        val gradleRunner = GradleRunnerRule()
+            .rootDir(tempDir)
+            .version(version)
+            .project("src/it/adapter-multiple-test-tasks-shared-results-dir")
+            .tasks("test", "integrationTest")
+            .build()
+
+        assertThat(gradleRunner.buildResult.task(":test")?.outcome)
+            .`as`("test task outcome")
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(gradleRunner.buildResult.task(":integrationTest")?.outcome)
+            .`as`("integrationTest task outcome")
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        val resultsDir = gradleRunner.projectDir.resolve("build/allure-results")
+        assertThat(resultsDir)
+            .`as`("shared Allure results directory")
+            .isNotEmptyDirectory()
+        assertThat(resultsDir.listFiles())
+            .`as`("Allure results test cases")
+            .filteredOn { file -> file.name.endsWith("result.json") }
+            .hasSize(2)
+    }
+}


### PR DESCRIPTION
## Summary
<!--
Describe the change and why it is needed.
Link related issues with `Fixes #123` when applicable.
-->

This change restores compatibility for builds that define more than one Test task while keeping allure.adapter.resultsDir shared and configurable as before.

Projects using patterns like custom integrationTest tasks and eager tasks.withType<Test>().all { ... } configuration could hit an error saying the shared resultsDir was already declared by another task. With this fix, those builds work again without requiring users to change their Gradle setup or split results into separate directories.

Fixes #175 

## Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

## Notes
<!--
Call out compatibility concerns, follow-up work, or review context that will help maintainers.
-->

[cla]: https://cla-assistant.io/accept/allure-framework/allure2