### PR TITLE
Add autoconfigure support for Allure AssertJ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: ${{ env.GRADLEW_CMD }} build -x test
 
       - name: Test with Allure
-        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test "-PtestGradleVersion=${{ matrix.gradle.version }}"
+        run: npx -y allure@3 run --rerun 1 --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test "-PtestGradleVersion=${{ matrix.gradle.version }}"
 
       - name: Upload test results
         if: always()

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ allure {
                 enabled.set(true)
                 autoconfigureListeners.set(true)
             }
+            assertj
             jbehave
             jbehave5
             karate {

--- a/allure-adapter-plugin/src/it/adapter-resolution-assertj/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-resolution-assertj/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    testImplementation 'org.assertj:assertj-core:3.27.7'
+}
+
+tasks.register('writeResolvedArtifacts') {
+    doLast {
+        buildDir.mkdirs()
+        def artifacts = configurations.testRuntimeClasspath.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/resolvedArtifacts.txt").text = artifacts
+    }
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AdapterHandler.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AdapterHandler.kt
@@ -18,6 +18,7 @@ open class AdapterHandler @Inject constructor(
     val karate by lazyCreating
     val scalatest by lazyCreating
     val testng by lazyCreating
+    val assertj by lazyCreating
     val spock by lazyCreating
     val cucumber4Jvm by lazyCreating
     val cucumber5Jvm by lazyCreating

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AllureJavaAdapter.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/config/AllureJavaAdapter.kt
@@ -38,6 +38,9 @@ internal enum class AllureJavaAdapter(
             compileAndRuntimeWithServices(adapterDependency, trimServicesFromJar)
         }
     }),
+    assertj("assertj", {
+        activateOn("org.assertj:assertj-core")
+    }),
     jbehave("jbehave", {
         activateOn("org.jbehave:jbehave-core") {
             matching {

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
@@ -28,7 +28,7 @@ class AdaptersTest {
                     gradleVersion,
                     "src/it/adapter-all",
                     arrayOf("printAdapters"),
-                    "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]",
+                    "[AdapterConfig{assertj}, AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]",
                 ),
             )
         }

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/SupportedFrameworksResolutionTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/SupportedFrameworksResolutionTest.kt
@@ -22,6 +22,7 @@ class SupportedFrameworksResolutionTest {
             arguments("src/it/adapter-resolution-junit5", "io.qameta.allure:allure-junit5:$ALLURE_JAVA_VERSION"),
             arguments("src/it/adapter-resolution-junit-platform", "io.qameta.allure:allure-junit-platform:$ALLURE_JAVA_VERSION"),
             arguments("src/it/adapter-resolution-testng", "io.qameta.allure:allure-testng:$ALLURE_JAVA_VERSION"),
+            arguments("src/it/adapter-resolution-assertj", "io.qameta.allure:allure-assertj:$ALLURE_JAVA_VERSION"),
             arguments("src/it/adapter-resolution-spock", "io.qameta.allure:allure-spock2:$ALLURE_JAVA_VERSION"),
             arguments("src/it/adapter-resolution-cucumber4-jvm", "io.qameta.allure:allure-cucumber4-jvm:$ALLURE_JAVA_VERSION"),
             arguments("src/it/adapter-resolution-cucumber5-jvm", "io.qameta.allure:allure-cucumber5-jvm:$ALLURE_JAVA_VERSION"),

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -18,6 +18,7 @@ allure {
             junitPlatform.autoconfigureListeners = false
             jbehave
             jbehave5
+            assertj
             karate.autoconfigureListeners = false
             scalatest
             spock

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -20,6 +20,7 @@ allure {
             }
             jbehave
             jbehave5
+            assertj
             karate {
                 autoconfigureListeners.set(false)
             }

--- a/testkit-jupiter/build.gradle.kts
+++ b/testkit-jupiter/build.gradle.kts
@@ -13,5 +13,11 @@ dependencies {
     implementation(gradleTestKit())
     implementation(libs.commons.io)
     implementation(libs.commons.text)
+    testImplementation(libs.allureJunit5)
     runtimeOnly(libs.junitPlatformLauncher)
+}
+
+tasks.test {
+    useJUnitPlatform()
+    systemProperty("junit.jupiter.extensions.autodetection.enabled", "true")
 }

--- a/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
+++ b/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
@@ -17,7 +17,9 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -31,6 +33,11 @@ import static org.apache.commons.lang3.RandomStringUtils.insecure;
 public class GradleRunnerRule {
 
     private static final File DEFAULT_ROOT_DIR = new File("build/gradle-testkit");
+
+    private static final List<String> NESTED_GRADLE_ENVIRONMENT_EXCLUDES = Arrays.asList(
+            "ALLURE_TESTPLAN_PATH",
+            "AS_TESTPLAN_PATH"
+    );
 
     private String project;
 
@@ -127,7 +134,18 @@ public class GradleRunnerRule {
                 .withGradleVersion(gradleVersion)
                 .withTestKitDir(testKitDir)
                 .withPluginClasspath()
+                .withEnvironment(nestedGradleEnvironment())
                 .forwardOutput();
+    }
+
+    private static Map<String, String> nestedGradleEnvironment() {
+        return nestedGradleEnvironment(System.getenv());
+    }
+
+    static Map<String, String> nestedGradleEnvironment(Map<String, String> source) {
+        Map<String, String> environment = new HashMap<>(source);
+        NESTED_GRADLE_ENVIRONMENT_EXCLUDES.forEach(environment::remove);
+        return environment;
     }
 
     public static BuildResult runBuild(File projectDir,

--- a/testkit-jupiter/src/test/java/io/qameta/allure/gradle/rule/GradleRunnerRuleTest.java
+++ b/testkit-jupiter/src/test/java/io/qameta/allure/gradle/rule/GradleRunnerRuleTest.java
@@ -1,0 +1,26 @@
+package io.qameta.allure.gradle.rule;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GradleRunnerRuleTest {
+
+    @Test
+    void nestedGradleEnvironmentDoesNotInheritAllureTestPlanFilters() {
+        Map<String, String> environment = new HashMap<>();
+        environment.put("ALLURE_TESTPLAN_PATH", "outer-allure-testplan.json");
+        environment.put("AS_TESTPLAN_PATH", "outer-as-testplan.json");
+        environment.put("PATH", "keep-me");
+
+        Map<String, String> nestedEnvironment = GradleRunnerRule.nestedGradleEnvironment(environment);
+
+        assertFalse(nestedEnvironment.containsKey("ALLURE_TESTPLAN_PATH"));
+        assertFalse(nestedEnvironment.containsKey("AS_TESTPLAN_PATH"));
+        assertEquals("keep-me", nestedEnvironment.get("PATH"));
+    }
+}


### PR DESCRIPTION
## Summary
<!--
Describe the change and why it is needed.
Link related issues with `Fixes #123` when applicable.
-->

This adds automatic setup for `allure-assertj` when a project uses `org.assertj:assertj-core`. Users who rely on AssertJ assertions can now get Allure’s AssertJ integration through the same autoconfigure behavior already used for JUnit, TestNG, Spock, Cucumber, and other supported frameworks.

The `assertj` adapter is also available in the explicit `frameworks` block, so users can opt into a focused configuration when they do not want every detected framework enabled:

```kotlin
allure {
    adapter {
        frameworks {
            assertj
        }
    }
}
```

The adapter-resolution test matrix now includes an AssertJ fixture to verify that `io.qameta.allure:allure-assertj` is added when AssertJ is present.

## Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

## Notes
<!--
Call out compatibility concerns, follow-up work, or review context that will help maintainers.
-->

[cla]: https://cla-assistant.io/accept/allure-framework/allure2