### PR TITLE
Run Gradle compatibility tests one version at a time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,20 +22,26 @@ concurrency:
 
 jobs:
   build:
-    name: 'Build (JDK ${{ matrix.java-version }}, Gradle ${{ matrix.test-gradle-version }}, ${{ matrix.os }})'
+    name: 'Build (JDK ${{ matrix.java-version }}, Gradle ${{ matrix.gradle.version }}, ${{ matrix.os }})'
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [ 'ubuntu', 'windows' ]
         java-version: [ '17', '21' ]
-        test-gradle-version: [ '9.4.1', '8.14.3', '8.11.1' ]
+        gradle:
+          - version: '9.4.1'
+            env-version: '9_4_1'
+          - version: '8.14.3'
+            env-version: '8_14_3'
+          - version: '8.11.1'
+            env-version: '8_11_1'
     env:
       MATRIX_OS: ${{ matrix.os }}
       MATRIX_JAVA_VERSION: ${{ matrix.java-version }}
-      MATRIX_TEST_GRADLE_VERSION: ${{ matrix.test-gradle-version }}
-      ALLURE_MATRIX_ENV: ${{ matrix.os }}-jdk-${{ matrix.java-version }}-gradle-${{ matrix.test-gradle-version }}
-      ALLURE_DUMP_NAME: allure-results-build-${{ matrix.os }}-jdk-${{ matrix.java-version }}-gradle-${{ matrix.test-gradle-version }}
+      MATRIX_TEST_GRADLE_VERSION: ${{ matrix.gradle.version }}
+      ALLURE_MATRIX_ENV: ${{ matrix.os }}-jdk-${{ matrix.java-version }}-gradle-${{ matrix.gradle.env-version }}
+      ALLURE_DUMP_NAME: allure-results-build-${{ matrix.os }}-jdk-${{ matrix.java-version }}-gradle-${{ matrix.gradle.version }}
       GRADLEW_CMD: ${{ matrix.os == 'windows' && '.\\gradlew.bat' || './gradlew' }}
     steps:
       - uses: actions/checkout@v6
@@ -59,7 +65,7 @@ jobs:
         run: ${{ env.GRADLEW_CMD }} build -x test
 
       - name: Test with Allure
-        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test -PtestGradleVersion=${{ matrix.test-gradle-version }}
+        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test -PtestGradleVersion=${{ matrix.gradle.version }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,18 +22,20 @@ concurrency:
 
 jobs:
   build:
-    name: 'Build (JDK ${{ matrix.java-version }}, ${{ matrix.os }})'
+    name: 'Build (JDK ${{ matrix.java-version }}, Gradle ${{ matrix.test-gradle-version }}, ${{ matrix.os }})'
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
         os: [ 'ubuntu', 'windows' ]
         java-version: [ '17', '21' ]
+        test-gradle-version: [ '9.4.1', '8.14.3', '8.11.1' ]
     env:
       MATRIX_OS: ${{ matrix.os }}
       MATRIX_JAVA_VERSION: ${{ matrix.java-version }}
-      ALLURE_MATRIX_ENV: ${{ matrix.os }}-jdk-${{ matrix.java-version }}
-      ALLURE_DUMP_NAME: allure-results-build-${{ matrix.os }}-jdk-${{ matrix.java-version }}
+      MATRIX_TEST_GRADLE_VERSION: ${{ matrix.test-gradle-version }}
+      ALLURE_MATRIX_ENV: ${{ matrix.os }}-jdk-${{ matrix.java-version }}-gradle-${{ matrix.test-gradle-version }}
+      ALLURE_DUMP_NAME: allure-results-build-${{ matrix.os }}-jdk-${{ matrix.java-version }}-gradle-${{ matrix.test-gradle-version }}
       GRADLEW_CMD: ${{ matrix.os == 'windows' && '.\\gradlew.bat' || './gradlew' }}
     steps:
       - uses: actions/checkout@v6
@@ -57,7 +59,7 @@ jobs:
         run: ${{ env.GRADLEW_CMD }} build -x test
 
       - name: Test with Allure
-        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test
+        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test -PtestGradleVersion=${{ matrix.test-gradle-version }}
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         run: ${{ env.GRADLEW_CMD }} build -x test
 
       - name: Test with Allure
-        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test -PtestGradleVersion=${{ matrix.gradle.version }}
+        run: npx -y allure@3 run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" -- ${{ env.GRADLEW_CMD }} test "-PtestGradleVersion=${{ matrix.gradle.version }}"
 
       - name: Upload test results
         if: always()

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AdaptersTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.io.TempDir
@@ -14,44 +15,23 @@ class AdaptersTest {
 
     companion object {
         @JvmStatic
-        fun getFrameworks() = listOf(
-            arguments(
-                "9.4.1",
-                "src/it/adapter-junit5-spock-kts",
-                arrayOf("printAdapters"),
-                "[AdapterConfig{junit5}, AdapterConfig{spock}]",
-            ),
-            arguments(
-                "8.14.3",
-                "src/it/adapter-junit5-spock-kts",
-                arrayOf("printAdapters"),
-                "[AdapterConfig{junit5}, AdapterConfig{spock}]",
-            ),
-            arguments(
-                "8.11.1",
-                "src/it/adapter-junit5-spock-kts",
-                arrayOf("printAdapters"),
-                "[AdapterConfig{junit5}, AdapterConfig{spock}]",
-            ),
-            arguments(
-                "9.4.1",
-                "src/it/adapter-all",
-                arrayOf("printAdapters"),
-                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]",
-            ),
-            arguments(
-                "8.11.1",
-                "src/it/adapter-all",
-                arrayOf("printAdapters"),
-                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]",
-            ),
-            arguments(
-                "8.14.3",
-                "src/it/adapter-all",
-                arrayOf("printAdapters"),
-                "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]",
-            ),
-        )
+        fun getFrameworks(): List<org.junit.jupiter.params.provider.Arguments> {
+            val gradleVersion = GradleTestVersion.current()
+            return listOf(
+                arguments(
+                    gradleVersion,
+                    "src/it/adapter-junit5-spock-kts",
+                    arrayOf("printAdapters"),
+                    "[AdapterConfig{junit5}, AdapterConfig{spock}]",
+                ),
+                arguments(
+                    gradleVersion,
+                    "src/it/adapter-all",
+                    arrayOf("printAdapters"),
+                    "[AdapterConfig{cucumber4Jvm}, AdapterConfig{cucumber5Jvm}, AdapterConfig{cucumber6Jvm}, AdapterConfig{cucumber7Jvm}, AdapterConfig{jbehave5}, AdapterConfig{jbehave}, AdapterConfig{junit4}, AdapterConfig{junit5}, AdapterConfig{junitPlatform}, AdapterConfig{karate}, AdapterConfig{scalatest}, AdapterConfig{spock}, AdapterConfig{testng}]",
+                ),
+            )
+        }
     }
 
     @ParameterizedTest(name = "{1} [{0}]")

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AspectjWeaverJvmArgsTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AspectjWeaverJvmArgsTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
@@ -15,14 +16,13 @@ class AspectjWeaverJvmArgsTest {
 
     companion object {
         @JvmStatic
-        fun data() = listOf(
-            arguments("9.4.1", "src/it/adapter-aspectj-weaver-disabled-kts", false),
-            arguments("8.14.3", "src/it/adapter-aspectj-weaver-disabled-kts", false),
-            arguments("8.11.1", "src/it/adapter-aspectj-weaver-disabled-kts", false),
-            arguments("9.4.1", "src/it/adapter-aspectj-weaver-enabled-kts", true),
-            arguments("8.14.3", "src/it/adapter-aspectj-weaver-enabled-kts", true),
-            arguments("8.11.1", "src/it/adapter-aspectj-weaver-enabled-kts", true),
-        )
+        fun data(): List<org.junit.jupiter.params.provider.Arguments> {
+            val gradleVersion = GradleTestVersion.current()
+            return listOf(
+                arguments(gradleVersion, "src/it/adapter-aspectj-weaver-disabled-kts", false),
+                arguments(gradleVersion, "src/it/adapter-aspectj-weaver-enabled-kts", true),
+            )
+        }
     }
 
     @ParameterizedTest(name = "{1} [{0}]")

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AssembleTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AssembleTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions
 import org.gradle.testkit.runner.TaskOutcome
@@ -16,9 +17,7 @@ class AssembleTest {
     companion object {
         @JvmStatic
         fun getFrameworks() = listOf(
-            arguments("9.4.1", "src/it/adapter-assemble", arrayOf("assemble")),
-            arguments("8.14.3", "src/it/adapter-assemble", arrayOf("assemble")),
-            arguments("8.11.1", "src/it/adapter-assemble", arrayOf("assemble")),
+            arguments(GradleTestVersion.current(), "src/it/adapter-assemble", arrayOf("assemble")),
         )
     }
 

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AutoconfigureDisabledDirectDependencyResolutionTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/AutoconfigureDisabledDirectDependencyResolutionTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.io.TempDir
@@ -13,7 +14,7 @@ class AutoconfigureDisabledDirectDependencyResolutionTest {
 
     companion object {
         @JvmStatic
-        fun data() = listOf("9.4.1", "8.14.3", "8.11.1")
+        fun data() = listOf(GradleTestVersion.current())
     }
 
     @ParameterizedTest(name = "{0}")

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CacheabilityTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CacheabilityTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.BuildResult
@@ -17,8 +18,7 @@ class CacheabilityTest {
     companion object {
         @JvmStatic
         fun data() = listOf(
-            arguments("9.4.1", "src/it/adapter-cache-junit5-kts"),
-            arguments("8.14.3", "src/it/adapter-cache-junit5-kts"),
+            arguments(GradleTestVersion.current(), "src/it/adapter-cache-junit5-kts"),
         )
     }
 

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/ConfigurationCacheTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/ConfigurationCacheTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
@@ -14,7 +15,7 @@ class ConfigurationCacheTest {
 
     companion object {
         @JvmStatic
-        fun data() = listOf("9.4.1", "8.14.3", "8.11.1")
+        fun data() = listOf(GradleTestVersion.current())
     }
 
     @ParameterizedTest(name = "configuration cache on {0}")

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CustomResultsDirTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/CustomResultsDirTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
@@ -14,7 +15,7 @@ class CustomResultsDirTest {
 
     companion object {
         @JvmStatic
-        fun versions() = listOf("9.4.1", "8.14.3", "8.11.1")
+        fun versions() = listOf(GradleTestVersion.current())
     }
 
     @ParameterizedTest(name = "{0}")

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/MultipleTestTasksSharedResultsDirTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/MultipleTestTasksSharedResultsDirTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
@@ -14,7 +15,7 @@ class MultipleTestTasksSharedResultsDirTest {
 
     companion object {
         @JvmStatic
-        fun versions() = listOf("9.4.1", "8.14.3", "8.11.1")
+        fun versions() = listOf(GradleTestVersion.current())
     }
 
     @ParameterizedTest(name = "{0}")

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/SupportedFrameworksResolutionTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/SupportedFrameworksResolutionTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.io.TempDir
@@ -39,7 +40,7 @@ class SupportedFrameworksResolutionTest {
     fun `resolved runtime classpath should contain the expected adapter`(project: String, expectedDependency: String) {
         val gradleRunner = GradleRunnerRule()
             .rootDir(tempDir)
-            .version("9.4.1")
+            .version(GradleTestVersion.current())
             .project(project)
             .tasks("writeResolvedArtifacts")
             .build()

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/UnsupportedFrameworksResolutionTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/UnsupportedFrameworksResolutionTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.adapter
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -14,7 +15,7 @@ class UnsupportedFrameworksResolutionTest {
     fun `unsupported testng versions should not resolve allure adapter`() {
         val gradleRunner = GradleRunnerRule()
             .rootDir(tempDir)
-            .version("9.4.1")
+            .version(GradleTestVersion.current())
             .project("src/it/adapter-resolution-testng-unsupported")
             .tasks("writeResolvedArtifacts")
             .build()

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/AggregatedReportTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/AggregatedReportTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.allure;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.io.TempDir;
@@ -7,7 +8,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -21,10 +21,9 @@ public class AggregatedReportTest {
     File tempDir;
 
     static Collection<org.junit.jupiter.params.provider.Arguments> getFrameworks() {
+        String gradleVersion = GradleTestVersion.current();
         return List.of(
-                arguments("9.4.1", "src/it/report-multi", new String[]{"allureAggregateReport"}),
-                arguments("8.14.3", "src/it/report-multi", new String[]{"allureAggregateReport"}),
-                arguments("8.11.1", "src/it/report-multi", new String[]{"allureAggregateReport"})
+                arguments(gradleVersion, "src/it/report-multi", new String[]{"allureAggregateReport"})
         );
     }
 

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CategoriesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CategoriesTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.allure;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,10 +19,9 @@ public class CategoriesTest {
     File tempDir;
 
     static Collection<org.junit.jupiter.params.provider.Arguments> getFrameworks() {
+        String gradleVersion = GradleTestVersion.current();
         return List.of(
-                arguments("9.4.1", "src/it/categories", new String[]{"allureReport"}),
-                arguments("8.14.3", "src/it/categories", new String[]{"allureReport"}),
-                arguments("8.11.1", "src/it/categories", new String[]{"allureReport"})
+                arguments(gradleVersion, "src/it/categories", new String[]{"allureReport"})
         );
     }
 

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CustomResultsDirTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/CustomResultsDirTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.allure;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,7 +20,7 @@ public class CustomResultsDirTest {
     File tempDir;
 
     static Collection<String> getVersions() {
-        return List.of("9.4.1", "8.14.3", "8.11.1");
+        return List.of(GradleTestVersion.current());
     }
 
     @ParameterizedTest(name = "{0}")

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/DependenciesTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.allure;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.io.TempDir;
@@ -7,8 +8,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,24 +18,25 @@ import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class DependenciesTest {
 
-    private static final String[][] IT_MATRIX = {
-            { "src/it/cucumber7-jvm",        "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/junit4",               "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/junit4-autoconfigure", "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/junit4-kotlin",        "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/junit5",               "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/junit5-5.8.1",         "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/testng",               "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/testng-autoconfigure", "9.4.1", "8.14.3", "8.11.1" },
-            { "src/it/spock",                "9.4.1", "8.14.3", "8.11.1" },
-    };
+    private static final List<String> IT_PROJECTS = List.of(
+            "src/it/cucumber7-jvm",
+            "src/it/junit4",
+            "src/it/junit4-autoconfigure",
+            "src/it/junit4-kotlin",
+            "src/it/junit5",
+            "src/it/junit5-5.8.1",
+            "src/it/testng",
+            "src/it/testng-autoconfigure",
+            "src/it/spock"
+    );
 
     @TempDir
     File tempDir;
 
     static Collection<org.junit.jupiter.params.provider.Arguments> getFrameworks() {
-        return Arrays.stream(IT_MATRIX)
-                .flatMap(it -> Arrays.stream(it).skip(1).map(version -> arguments(version, it[0])))
+        String gradleVersion = GradleTestVersion.current();
+        return IT_PROJECTS.stream()
+                .map(project -> arguments(gradleVersion, project))
                 .collect(Collectors.toList());
     }
 

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/ExposeArtifactsTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/ExposeArtifactsTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.allure;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.io.TempDir;
@@ -18,7 +19,7 @@ public class ExposeArtifactsTest {
     File tempDir;
 
     static Collection<String> getFrameworks() {
-        return List.of("9.4.1", "8.14.3", "8.11.1");
+        return List.of(GradleTestVersion.current());
     }
 
     @ParameterizedTest(name = "{0}")

--- a/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
+++ b/allure-plugin/src/test/java/io/qameta/allure/gradle/allure/TestNgSpiOffTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.allure;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.io.TempDir;
@@ -19,7 +20,7 @@ public class TestNgSpiOffTest {
     File tempDir;
 
     static Collection<String> getFrameworks() {
-        return List.of("9.4.1", "8.14.3", "8.11.1");
+        return List.of(GradleTestVersion.current());
     }
 
     @ParameterizedTest(name = "{0}")

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3AggregateReportTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3AggregateReportTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.assertj.core.api.Assertions.assertThat
@@ -52,10 +53,11 @@ class Allure3AggregateReportTest {
             "--no-watch-fs",
             "allureAggregateReport"
         )
-        val buildResult = GradleRunnerRule.runBuild(projectDir, "9.4.1", arguments) {
+        val gradleVersion = GradleTestVersion.current()
+        val buildResult = GradleRunnerRule.runBuild(projectDir, gradleVersion, arguments) {
             GradleRunner.create()
                 .withProjectDir(projectDir)
-                .withGradleVersion("9.4.1")
+                .withGradleVersion(gradleVersion)
                 .withPluginClasspath()
                 .withTestKitDir(GradleRunnerRule.testKitDirFor(projectDir))
                 .withArguments(arguments)

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureRuntimeMatrixSupport.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureRuntimeMatrixSupport.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.assertj.core.api.Assertions.assertThat
@@ -52,7 +53,7 @@ internal object AllureRuntimeMatrixSupport {
         }
     }
 
-    fun runner(projectDir: File, gradleVersion: String = "9.4.1"): GradleRunner = GradleRunner.create()
+    fun runner(projectDir: File, gradleVersion: String = GradleTestVersion.current()): GradleRunner = GradleRunner.create()
         .withProjectDir(projectDir)
         .withGradleVersion(gradleVersion)
         .withPluginClasspath()
@@ -61,8 +62,9 @@ internal object AllureRuntimeMatrixSupport {
 
     fun build(projectDir: File, vararg tasks: String): BuildResult {
         val arguments = commonArgs(*tasks)
-        return GradleRunnerRule.runBuild(projectDir, "9.4.1", arguments) {
-            runner(projectDir)
+        val gradleVersion = GradleTestVersion.current()
+        return GradleRunnerRule.runBuild(projectDir, gradleVersion, arguments) {
+            runner(projectDir, gradleVersion)
                 .withArguments(arguments)
                 .build()
         }

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
@@ -15,14 +16,13 @@ class DslTest {
 
     companion object {
         @JvmStatic
-        fun getFrameworks() = listOf(
-            arguments("9.4.1", "src/it/full-dsl-kotlin"),
-            arguments("8.14.3", "src/it/full-dsl-kotlin"),
-            arguments("8.11.1", "src/it/full-dsl-kotlin"),
-            arguments("9.4.1", "src/it/full-dsl-groovy"),
-            arguments("8.14.3", "src/it/full-dsl-groovy"),
-            arguments("8.11.1", "src/it/full-dsl-groovy"),
-        )
+        fun getFrameworks(): List<org.junit.jupiter.params.provider.Arguments> {
+            val gradleVersion = GradleTestVersion.current()
+            return listOf(
+                arguments(gradleVersion, "src/it/full-dsl-kotlin"),
+                arguments(gradleVersion, "src/it/full-dsl-groovy"),
+            )
+        }
     }
 
     @ParameterizedTest(name = "{1} [{0}]")

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/KotlinDslReportTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/KotlinDslReportTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
@@ -15,7 +16,7 @@ class KotlinDslReportTest {
 
     companion object {
         @JvmStatic
-        fun versions() = listOf("9.4.1", "8.14.3", "8.11.1")
+        fun versions() = listOf(GradleTestVersion.current())
     }
 
     @ParameterizedTest(name = "[{0}]")

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/TestAndAllureReportTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/TestAndAllureReportTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions
 import org.gradle.testkit.runner.TaskOutcome
@@ -16,11 +17,10 @@ class TestAndAllureReportTest {
     companion object {
         @JvmStatic
         fun getFrameworks() = buildList {
-            for (gradleVersion in listOf("9.4.1", "8.14.3", "8.11.1")) {
-                for (project in listOf("src/it/junit5-5.8.1")) {
-                    for (dependsOnTests in listOf(true, false)) {
-                        add(arguments(gradleVersion, project, dependsOnTests))
-                    }
+            val gradleVersion = GradleTestVersion.current()
+            for (project in listOf("src/it/junit5-5.8.1")) {
+                for (dependsOnTests in listOf(true, false)) {
+                    add(arguments(gradleVersion, project, dependsOnTests))
                 }
             }
         }

--- a/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
+++ b/allure-report-plugin/src/test/java/io/qameta/allure/gradle/report/ReportOnlyTest.java
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report;
 
+import io.qameta.allure.gradle.rule.GradleTestVersion;
 import io.qameta.allure.gradle.rule.GradleRunnerRule;
 import org.gradle.testkit.runner.BuildResult;
 import org.junit.jupiter.api.io.TempDir;
@@ -21,9 +22,7 @@ public class ReportOnlyTest {
 
     static Collection<org.junit.jupiter.params.provider.Arguments> getFrameworks() {
         return List.of(
-                arguments("src/it/report-only", "9.4.1"),
-                arguments("src/it/report-only", "8.14.3"),
-                arguments("src/it/report-only", "8.11.1")
+                arguments("src/it/report-only", GradleTestVersion.current())
         );
     }
 

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.apache.commons.compress.archivers.zip.UnixStat
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry
@@ -319,7 +320,7 @@ class Allure3ReportIntegrationTest {
 
     private fun runner(projectDir: File): GradleRunner = GradleRunner.create()
         .withProjectDir(projectDir)
-        .withGradleVersion("9.4.1")
+        .withGradleVersion(GradleTestVersion.current())
         .withPluginClasspath()
         .withTestKitDir(GradleRunnerRule.testKitDirFor(projectDir))
         .forwardOutput()
@@ -333,7 +334,7 @@ class Allure3ReportIntegrationTest {
     )
 
     private fun runBuild(projectDir: File, vararg tasks: String) =
-        GradleRunnerRule.runBuild(projectDir, "9.4.1", commonArgs(*tasks)) {
+        GradleRunnerRule.runBuild(projectDir, GradleTestVersion.current(), commonArgs(*tasks)) {
             runner(projectDir).withArguments(commonArgs(*tasks)).build()
         }
 }

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureServeIntegrationTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureServeIntegrationTest.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.rule.GradleTestVersion
 import io.qameta.allure.gradle.rule.GradleRunnerRule
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.GradleRunner
@@ -37,10 +38,11 @@ class AllureServeIntegrationTest {
             "--no-watch-fs",
             "allureServe"
         )
-        val buildResult = GradleRunnerRule.runBuild(projectDir, "9.4.1", arguments) {
+        val gradleVersion = GradleTestVersion.current()
+        val buildResult = GradleRunnerRule.runBuild(projectDir, gradleVersion, arguments) {
             GradleRunner.create()
                 .withProjectDir(projectDir)
-                .withGradleVersion("9.4.1")
+                .withGradleVersion(gradleVersion)
                 .withPluginClasspath()
                 .withTestKitDir(GradleRunnerRule.testKitDirFor(projectDir))
                 .withArguments(arguments)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,19 @@
+import org.gradle.api.tasks.testing.Test
+
 plugins {
     id("allure-gradle.root-build")
 }
 
 group = "io.qameta.allure"
+
+val testGradleVersionProperty = "testGradleVersion"
+val defaultTestGradleVersion = "9.4.1"
+
+allprojects {
+    tasks.withType<Test>().configureEach {
+        val testGradleVersion = providers.gradleProperty(testGradleVersionProperty)
+            .orElse(defaultTestGradleVersion)
+        inputs.property(testGradleVersionProperty, testGradleVersion)
+        systemProperty(testGradleVersionProperty, testGradleVersion.get())
+    }
+}

--- a/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
+++ b/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleRunnerRule.java
@@ -36,7 +36,7 @@ public class GradleRunnerRule {
 
     private String[] tasks = new String[0];
 
-    private String gradleVersion = "9.4.1";
+    private String gradleVersion = GradleTestVersion.current();
 
     private File rootDir = DEFAULT_ROOT_DIR;
 

--- a/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleTestVersion.java
+++ b/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleTestVersion.java
@@ -1,0 +1,25 @@
+package io.qameta.allure.gradle.rule;
+
+/**
+ * Resolves the Gradle TestKit version used by integration tests.
+ */
+public final class GradleTestVersion {
+
+    public static final String PROPERTY_NAME = "testGradleVersion";
+
+    public static final String DEFAULT_VERSION = "9.4.1";
+
+    private GradleTestVersion() {
+    }
+
+    public static String current() {
+        String configured = System.getProperty(PROPERTY_NAME);
+        String version = configured == null ? DEFAULT_VERSION : configured.trim();
+        if (version.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "System property " + PROPERTY_NAME + " must not be blank"
+            );
+        }
+        return version;
+    }
+}


### PR DESCRIPTION
## Summary
<!--
Describe the change and why it is needed.
Link related issues with `Fixes #123` when applicable.
-->


This change updates the test suite so each test run checks against a single Gradle version. By default, tests still run with Gradle `9.4.1`, and other supported versions can now be selected with `-PtestGradleVersion=<version>`.

The GitHub Actions build now runs the supported Gradle versions through the CI matrix instead of expanding them inside individual tests. This keeps coverage for Gradle `9.4.1`, `8.14.3`, and `8.11.1`, while avoiding conflicts caused by multiple Gradle versions starting TestKit daemons in the same test invocation.

Example:

```bash
./gradlew test -PtestGradleVersion=8.11.1
```

## Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

## Notes
<!--
Call out compatibility concerns, follow-up work, or review context that will help maintainers.
-->

[cla]: https://cla-assistant.io/accept/allure-framework/allure2