### PR TITLE
Enable Javadoc descriptions automatically for Allure Java projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ allure {
 
         autoconfigure.set(true)
         autoconfigureListeners.set(true)
+        autoconfigureJavadocDescriptions.set(true)
         aspectjWeaver.set(true)
 
         // By default, categories.json is detected in src/test/resources/../categories.json,
@@ -239,6 +240,15 @@ allure {
         }
     }
 }
+```
+
+### Using custom Javadoc description processing
+
+`allure-gradle` adds `io.qameta.allure:allure-descriptions-javadoc` to Java annotation
+processor configurations by default. Disable it when you configure description annotation processing manually:
+
+```kotlin
+allure.adapter.autoconfigureJavadocDescriptions.set(false)
 ```
 
 ## Report generation

--- a/allure-adapter-plugin/src/it/adapter-javadoc-descriptions/build.gradle
+++ b/allure-adapter-plugin/src/it/adapter-javadoc-descriptions/build.gradle
@@ -1,0 +1,38 @@
+plugins {
+    id 'java'
+    id 'io.qameta.allure-adapter'
+}
+
+repositories {
+    mavenCentral()
+}
+
+allure {
+    adapter {
+        allureJavaVersion = '2.34.0'
+        if (providers.gradleProperty('disableJavadocDescriptions').map { it.toBoolean() }.orElse(false).get()) {
+            autoconfigureJavadocDescriptions = false
+        }
+    }
+}
+
+dependencies {
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.10.2'
+}
+
+tasks.register('writeJavadocDescriptionArtifacts') {
+    dependsOn tasks.named('compileTestJava')
+    doLast {
+        buildDir.mkdirs()
+        def processorArtifacts = configurations.testAnnotationProcessor.resolvedConfiguration.resolvedArtifacts.collect {
+            "${it.moduleVersion.id.group}:${it.name}:${it.moduleVersion.id.version}"
+        }.sort().join('\n')
+        file("$buildDir/testAnnotationProcessors.txt").text = processorArtifacts
+
+        def descriptionsDir = file("$buildDir/classes/java/test/META-INF/allureDescriptions")
+        def descriptions = descriptionsDir.exists()
+                ? descriptionsDir.listFiles().collect { it.text.trim() }.sort().join('\n')
+                : ''
+        file("$buildDir/javadocDescriptions.txt").text = descriptions
+    }
+}

--- a/allure-adapter-plugin/src/it/adapter-javadoc-descriptions/src/test/java/tests/JavadocDescriptionTest.java
+++ b/allure-adapter-plugin/src/it/adapter-javadoc-descriptions/src/test/java/tests/JavadocDescriptionTest.java
@@ -1,0 +1,13 @@
+package tests;
+
+import io.qameta.allure.Description;
+
+class JavadocDescriptionTest {
+
+    /**
+     * A description from Javadoc.
+     */
+    @Description
+    void hasJavadocDescription() {
+    }
+}

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterExtension.kt
@@ -62,6 +62,12 @@ open class AllureAdapterExtension @Inject constructor(
     val autoconfigureListeners: Property<Boolean> = objects.property<Boolean>().convention(autoconfigure)
 
     /**
+     * Automatically add the Javadoc description annotation processor.
+     * This can be disabled when the project configures annotation processing manually.
+     */
+    val autoconfigureJavadocDescriptions: Property<Boolean> = objects.property<Boolean>().convention(autoconfigure)
+
+    /**
      * Automatically add AspectJ waver
      */
     val aspectjWeaver = objects.property<Boolean>().convention(autoconfigure)

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterPlugin.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterPlugin.kt
@@ -14,6 +14,7 @@ import org.gradle.api.Project
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.Usage
 import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.SourceSetContainer
 import org.gradle.api.tasks.testing.Test
 import org.gradle.kotlin.dsl.*
 
@@ -51,6 +52,7 @@ open class AllureAdapterPlugin : Plugin<Project> {
         }
 
         autoconfigureDependencyRules(adapterExtension)
+        autoconfigureJavadocDescriptions(adapterExtension)
         configureTestTasks(adapterExtension)
         val artifactType = Attribute.of("artifactType", String::class.java)
 
@@ -102,6 +104,21 @@ open class AllureAdapterPlugin : Plugin<Project> {
                         rule.configure(this)
                     }
                 }
+            }
+        }
+    }
+
+    private fun Project.autoconfigureJavadocDescriptions(extension: AllureAdapterExtension) {
+        pluginManager.withPlugin("java-base") {
+            val descriptionsProcessor = extension.autoconfigureJavadocDescriptions.flatMap { enabled ->
+                if (enabled) {
+                    extension.allureJavaVersion.map { "io.qameta.allure:allure-descriptions-javadoc:$it" }
+                } else {
+                    providers.provider<String> { null }
+                }
+            }
+            extensions.getByType<SourceSetContainer>().configureEach {
+                dependencies.addProvider(annotationProcessorConfigurationName, descriptionsProcessor)
             }
         }
     }

--- a/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/JavadocDescriptionsAutoconfigureTest.kt
+++ b/allure-adapter-plugin/src/test/kotlin/io/qameta/allure/gradle/adapter/JavadocDescriptionsAutoconfigureTest.kt
@@ -1,0 +1,49 @@
+package io.qameta.allure.gradle.adapter
+
+import io.qameta.allure.gradle.rule.GradleTestVersion
+import io.qameta.allure.gradle.rule.GradleRunnerRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class JavadocDescriptionsAutoconfigureTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @Test
+    fun `javadoc descriptions processor should be added by default`() {
+        val gradleRunner = GradleRunnerRule()
+            .rootDir(tempDir)
+            .version(GradleTestVersion.current())
+            .project("src/it/adapter-javadoc-descriptions")
+            .tasks("writeJavadocDescriptionArtifacts")
+            .build()
+
+        val processors = gradleRunner.projectDir.resolve("build/testAnnotationProcessors.txt").readText()
+        val descriptions = gradleRunner.projectDir.resolve("build/javadocDescriptions.txt").readText()
+
+        assertThat(processors)
+            .contains("io.qameta.allure:allure-descriptions-javadoc:2.34.0")
+        assertThat(descriptions)
+            .contains("A description from Javadoc.")
+    }
+
+    @Test
+    fun `javadoc descriptions processor should have an opt-out`() {
+        val gradleRunner = GradleRunnerRule()
+            .rootDir(tempDir)
+            .version(GradleTestVersion.current())
+            .project("src/it/adapter-javadoc-descriptions")
+            .tasks("writeJavadocDescriptionArtifacts", "-PdisableJavadocDescriptions=true")
+            .build()
+
+        val processors = gradleRunner.projectDir.resolve("build/testAnnotationProcessors.txt").readText()
+        val descriptions = gradleRunner.projectDir.resolve("build/javadocDescriptions.txt").readText()
+
+        assertThat(processors)
+            .doesNotContain("io.qameta.allure:allure-descriptions-javadoc:")
+        assertThat(descriptions)
+            .isBlank()
+    }
+}

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -10,6 +10,7 @@ allure {
     environment["TZ"] = "UTC"
     adapter {
         resultsDir = layout.buildDirectory.dir("custom-allure-results")
+        autoconfigureJavadocDescriptions = false
         frameworks {
             junit5 {
                 adapterVersion = "42.0"

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -10,6 +10,7 @@ allure {
     environment.put("TZ", "UTC")
     adapter {
         resultsDir.set(layout.buildDirectory.dir("custom-allure-results"))
+        autoconfigureJavadocDescriptions.set(false)
         frameworks {
             junit5 {
                 adapterVersion.set("42.0")


### PR DESCRIPTION
## Summary
<!--
Describe the change and why it is needed.
Link related issues with `Fixes #123` when applicable.
-->

This PR enables automatic setup of `allure-descriptions-javadoc` for Java projects using the Allure Gradle adapter. When enabled, test method Javadoc can be picked up for Allure descriptions without users manually adding the Javadoc description processor dependency.

The feature is enabled by default and follows the existing `autoconfigure` setting. Users who manage annotation processing themselves can opt out explicitly:

```kotlin
allure.adapter.autoconfigureJavadocDescriptions.set(false)
```

## Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

## Notes
<!--
Call out compatibility concerns, follow-up work, or review context that will help maintainers.
-->

[cla]: https://cla-assistant.io/accept/allure-framework/allure2