### PR TITLE
Support custom Allure 3 config files in report tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,22 @@ allure {
 
 To enable it for a single invocation without changing the DSL, run `./gradlew allureReport --single-file=true`.
 
+For Allure 3, you can provide a custom config file, for example to configure environments, custom grouping,
+report name, or theme:
+
+```kotlin
+allure {
+    report {
+        configFile.set(layout.projectDirectory.file("allurerc.mjs"))
+    }
+}
+```
+
+To use a custom Allure 3 config file for a single invocation, run `./gradlew allureReport --config-file=allurerc.mjs`.
+When `configFile` is set, Allure 3-specific options such as `singleFile`, environments, grouping, report name,
+and theme should be configured in that file. The Gradle task still passes its `reportDir` as `--output`.
+In this mode, Gradle's `singleFile` property and the `--single-file` task option are ignored for Allure 3.
+
 ### Running tests before building the report
 
 By default, `allureReport` task will NOT execute tests.

--- a/allure-plugin/src/it/full-dsl-groovy/build.gradle
+++ b/allure-plugin/src/it/full-dsl-groovy/build.gradle
@@ -52,12 +52,15 @@ allure {
         reportDir = layout.buildDirectory.dir("allure/reports")
         dependsOnTests = true
         dependsOnTests()
+        configFile = layout.projectDirectory.file("allurerc.mjs")
     }
     report.reportDir = file("$buildDir/allure/reports")
     report.dependsOnTests = true
+    report.configFile = layout.projectDirectory.file("allurerc.mjs")
 }
 allure.commandline.downloadUrlPattern = "localhost"
 allure.report.dependsOnTests = true
+allure.report.configFile = layout.projectDirectory.file("allurerc.mjs")
 
 tasks.register("testDsl") {
     doLast {

--- a/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
+++ b/allure-plugin/src/it/full-dsl-kotlin/build.gradle.kts
@@ -55,12 +55,15 @@ allure {
         reportDir.set(layout.buildDirectory.dir("allure/reports"))
         dependsOnTests.set(true)
         dependsOnTests()
+        configFile.set(layout.projectDirectory.file("allurerc.mjs"))
     }
     report.reportDir.set(buildDir.resolve("allure/reports"))
     report.dependsOnTests.set(true)
+    report.configFile.set(layout.projectDirectory.file("allurerc.mjs"))
 }
 allure.commandline.downloadUrlPattern.set("localhost")
 allure.report.dependsOnTests.set(true)
+allure.report.configFile.set(layout.projectDirectory.file("allurerc.mjs"))
 
 val testDsl by tasks.registering {
     doLast {

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3AggregateReportTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3AggregateReportTest.kt
@@ -77,6 +77,86 @@ class Allure3AggregateReportTest {
             .exists()
     }
 
+    @Test
+    fun `allureAggregateReport should use custom Allure 3 config file`() {
+        assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS), "Fake Allure 3 runtime tests currently support Unix-like systems only")
+
+        val projectDir = File(tempDir, "allure3-aggregate-custom-config").apply { mkdirs() }
+        File("src/it/report-multi").copyRecursively(projectDir, overwrite = true)
+
+        val nodeArchive = createFakeNodeArchive(projectDir)
+        val fakePackage = projectDir.resolve("fake-allure.tgz").apply {
+            writeText("fake")
+        }
+        val customConfig = projectDir.resolve("allurerc.mjs").apply {
+            writeText(
+                """
+                export default {
+                    name: "Aggregate Custom Config",
+                    environments: {
+                        linux: { name: "Linux", matcher: () => true },
+                    },
+                };
+                """.trimIndent()
+            )
+        }
+
+        projectDir.resolve("build.gradle").writeText(
+            """
+            plugins {
+                id 'io.qameta.allure-aggregate-report'
+            }
+
+            configurations.allureAggregateReport.dependencies.clear()
+            dependencies {
+                allureAggregateReport(project(":module1"))
+                allureAggregateReport(project(":module2"))
+                allureAggregateReport(project(":module3"))
+                allureNodeDistribution(files('${nodeArchive.absolutePath.replace("\\", "/")}'))
+                allure3Package(files('${fakePackage.absolutePath.replace("\\", "/")}'))
+            }
+
+            allure {
+                report.configFile = layout.projectDirectory.file('allurerc.mjs')
+            }
+            """.trimIndent()
+        )
+
+        val arguments = listOf(
+            "--stacktrace",
+            "--info",
+            "-Porg.gradle.daemon=false",
+            "--no-watch-fs",
+            "allureAggregateReport"
+        )
+        val gradleVersion = GradleTestVersion.current()
+        val buildResult = GradleRunnerRule.runBuild(projectDir, gradleVersion, arguments) {
+            GradleRunner.create()
+                .withProjectDir(projectDir)
+                .withGradleVersion(gradleVersion)
+                .withPluginClasspath()
+                .withTestKitDir(GradleRunnerRule.testKitDirFor(projectDir))
+                .withArguments(arguments)
+                .forwardOutput()
+                .build()
+        }
+
+        assertThat(buildResult.task(":allureAggregateReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/tmp/allureAggregateReport/allurerc.json"))
+            .doesNotExist()
+
+        val reportDir = projectDir.resolve("build/reports/allure-report/allureAggregateReport")
+        assertThat(reportDir.resolve("summary.json"))
+            .exists()
+
+        val invocations = projectDir.resolve("build/allure/commandline/node/invocations.txt").readText()
+        assertThat(invocations)
+            .contains("command=generate")
+            .contains("--config ${customConfig.canonicalPath}")
+            .contains("--output ${reportDir.canonicalPath}")
+    }
+
     private fun createFakeNodeArchive(projectDir: File): File {
         val rootDir = projectDir.resolve("fake-node")
         val nodeRoot = rootDir.resolve("node-v22.22.0-test")
@@ -89,19 +169,37 @@ class Allure3AggregateReportTest {
             """
             #!/bin/sh
             SCRIPT_DIR=${'$'}(CDPATH= cd -- "${'$'}(dirname "${'$'}0")" && pwd)
+            LOG_FILE="${'$'}SCRIPT_DIR/../invocations.txt"
+            CLI_FILE="${'$'}1"
             shift
             COMMAND="${'$'}1"
             shift
+            {
+              printf 'cli=%s\n' "${'$'}CLI_FILE"
+              printf 'command=%s\n' "${'$'}COMMAND"
+              printf 'args=%s\n' "${'$'}*"
+            } >> "${'$'}LOG_FILE"
             if [ "${'$'}COMMAND" = "generate" ]; then
               CONFIG=""
+              OUTPUT=""
               while [ "${'$'}#" -gt 0 ]; do
-                if [ "${'$'}1" = "--config" ]; then
-                  CONFIG="${'$'}2"
-                  break
-                fi
-                shift
+                case "${'$'}1" in
+                  --config)
+                    CONFIG="${'$'}2"
+                    shift 2
+                    ;;
+                  --output|-o)
+                    OUTPUT="${'$'}2"
+                    shift 2
+                    ;;
+                  *)
+                    shift
+                    ;;
+                esac
               done
-              OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              if [ -z "${'$'}OUTPUT" ]; then
+                OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              fi
               mkdir -p "${'$'}OUTPUT"
               printf '{}' > "${'$'}OUTPUT/summary.json"
             fi

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureRuntimeMatrixSupport.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllureRuntimeMatrixSupport.kt
@@ -164,14 +164,25 @@ internal object AllureRuntimeMatrixSupport {
             } >> "${'$'}LOG_FILE"
             if [ "${'$'}COMMAND" = "generate" ]; then
               CONFIG=""
+              OUTPUT=""
               while [ "${'$'}#" -gt 0 ]; do
-                if [ "${'$'}1" = "--config" ]; then
-                  CONFIG="${'$'}2"
-                  break
-                fi
-                shift
+                case "${'$'}1" in
+                  --config)
+                    CONFIG="${'$'}2"
+                    shift 2
+                    ;;
+                  --output|-o)
+                    OUTPUT="${'$'}2"
+                    shift 2
+                    ;;
+                  *)
+                    shift
+                    ;;
+                esac
               done
-              OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              if [ -z "${'$'}OUTPUT" ]; then
+                OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              fi
               mkdir -p "${'$'}OUTPUT"
               printf '{}' > "${'$'}OUTPUT/summary.json"
             fi

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/AllureReportExtension.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/AllureReportExtension.kt
@@ -1,6 +1,7 @@
 package io.qameta.allure.gradle.report
 
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.reporting.ReportingExtension
@@ -52,4 +53,9 @@ open class AllureReportExtension @Inject constructor(
     val singleFile: Property<Boolean> = objects.property<Boolean>().convention(
         false
     )
+
+    /**
+     * Path to a custom Allure 3 config file.
+     */
+    val configFile: RegularFileProperty = objects.fileProperty()
 }

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureReport.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureReport.kt
@@ -6,7 +6,11 @@ import io.qameta.allure.gradle.base.tasks.ConditionalArgumentProvider
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.the
@@ -39,11 +43,23 @@ abstract class AllureReport : AllureExecTask() {
         project.the<AllureExtension>().report.singleFile
     )
 
+    @Optional
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    val configFile = objects.fileProperty().convention(
+        project.the<AllureExtension>().report.configFile
+    )
+
     @Option(option = "single-file", description = "Generate a single-file Allure report")
     fun setSingleFile(enabled: String) {
         val parsed = enabled.toBooleanStrictOrNull()
             ?: throw IllegalArgumentException("single-file expects true or false, got '$enabled'")
         singleFile.set(parsed)
+    }
+
+    @Option(option = "config-file", description = "The Allure 3 config file to use")
+    fun setConfigFile(path: String) {
+        configFile.set(layout.file(providers.provider { File(path) }))
     }
 
     @get:Internal
@@ -70,7 +86,9 @@ abstract class AllureReport : AllureExecTask() {
                 args.addAll(rawResults)
                 if (usesAllure3Runtime()) {
                     args += "--config"
-                    args += allure3ConfigFile.get().asFile.absolutePath
+                    args += resolveAllure3ConfigFile().absolutePath
+                    args += "--output"
+                    args += reportDir.get().asFile.absolutePath
                 } else {
                     args += "-o"
                     args += reportDir.get().asFile.absolutePath
@@ -87,16 +105,25 @@ abstract class AllureReport : AllureExecTask() {
     }
 
     override fun exec() {
+        require(usesAllure3Runtime() || !configFile.isPresent) {
+            "allure.report.configFile is supported only for Allure 3. " +
+                "Set allure.version to a 3.x release or remove configFile."
+        }
         if (usesAllure3Runtime()) {
             if (clean.get()) {
                 project.delete(reportDir.get().asFile)
             }
-            writeAllure3Config(
-                file = allure3ConfigFile.get().asFile,
-                outputDir = reportDir.get().asFile,
-                singleFile = singleFile.get()
-            )
+            if (!configFile.isPresent) {
+                writeAllure3Config(
+                    file = allure3ConfigFile.get().asFile,
+                    outputDir = reportDir.get().asFile,
+                    singleFile = singleFile.get()
+                )
+            }
         }
         super.exec()
     }
+
+    private fun resolveAllure3ConfigFile(): File =
+        configFile.orNull?.asFile ?: allure3ConfigFile.get().asFile
 }

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureServe.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/tasks/AllureServe.kt
@@ -1,16 +1,22 @@
 package io.qameta.allure.gradle.report.tasks
 
+import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.base.tasks.AllureExecTask
 import io.qameta.allure.gradle.base.tasks.ConditionalArgumentProvider
 import org.apache.tools.ant.taskdefs.condition.Os
 import org.gradle.api.file.ProjectLayout
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.options.Option
 import org.gradle.kotlin.dsl.property
 import org.gradle.kotlin.dsl.the
 import org.gradle.process.ExecOperations
 import org.gradle.work.DisableCachingByDefault
 import report
+import java.io.File
 import java.io.InputStream
 import java.io.PrintStream
 import java.lang.management.ManagementFactory
@@ -44,7 +50,7 @@ abstract class AllureServe : AllureExecTask() {
 
     @get:Internal
     val allure3ReportDir = objects.directoryProperty().convention(
-        project.the<io.qameta.allure.gradle.base.AllureExtension>().report.reportDir.map {
+        project.the<AllureExtension>().report.reportDir.map {
             it.dir(this@AllureServe.name)
         }
     )
@@ -54,9 +60,21 @@ abstract class AllureServe : AllureExecTask() {
         providers.provider { temporaryDir.resolve("allurerc.json") }
     )
 
+    @Optional
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    val configFile = objects.fileProperty().convention(
+        project.the<AllureExtension>().report.configFile
+    )
+
     @Option(option = "port", description = "This port will be used to start web server for the report")
     fun setPort(port: String) {
         this.port.set(port.toInt())
+    }
+
+    @Option(option = "config-file", description = "The Allure 3 config file to use")
+    fun setConfigFile(path: String) {
+        configFile.set(layout.file(providers.provider { File(path) }))
     }
 
     init {
@@ -85,6 +103,10 @@ abstract class AllureServe : AllureExecTask() {
     }
 
     override fun exec() {
+        require(usesAllure3Runtime() || !configFile.isPresent) {
+            "allure.report.configFile is supported only for Allure 3. " +
+                "Set allure.version to a 3.x release or remove configFile."
+        }
         if (usesAllure3Runtime()) {
             execAllure3()
             return
@@ -108,20 +130,24 @@ abstract class AllureServe : AllureExecTask() {
 
         val allureExecutablePath = resolveAllureExecutable().absolutePath
         val resolvedEnvironment = resolveEnvironment()
-        val configFile = allure3ConfigFile.get().asFile
+        val configFile = resolveAllure3ConfigFile()
         val reportDir = allure3ReportDir.get().asFile
 
-        writeAllure3Config(
-            file = configFile,
-            outputDir = reportDir,
-            singleFile = false
-        )
+        if (!this.configFile.isPresent) {
+            writeAllure3Config(
+                file = configFile,
+                outputDir = reportDir,
+                singleFile = false
+            )
+        }
 
         val generateArgs = mutableListOf<String>().apply {
             add("generate")
             addAll(rawResults.get().map { it.absolutePath })
             add("--config")
             add(configFile.absolutePath)
+            add("--output")
+            add(reportDir.absolutePath)
         }
 
         execOperations.exec {
@@ -210,6 +236,9 @@ abstract class AllureServe : AllureExecTask() {
             start()
         }
     }
+
+    private fun resolveAllure3ConfigFile(): File =
+        configFile.orNull?.asFile ?: allure3ConfigFile.get().asFile
 }
 
 internal fun buildWindowsCommand(allureExecutable: String, allureArgs: List<Any>): List<String> =

--- a/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
+++ b/allure-report-plugin/src/test/kotlin/io/qameta/allure/gradle/report/Allure3ReportIntegrationTest.kt
@@ -104,6 +104,69 @@ class Allure3ReportIntegrationTest {
     }
 
     @Test
+    fun `allureReport should use custom Allure 3 config file`() {
+        assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS), "Fake Allure 3 runtime tests currently support Unix-like systems only")
+
+        val projectDir = createAllure3Project(
+            singleFile = false,
+            extraAllureBlock = """
+                report.configFile = layout.projectDirectory.file('allurerc.mjs')
+            """.trimIndent()
+        )
+        val customConfig = projectDir.resolve("allurerc.mjs").apply {
+            writeText(
+                """
+                export default {
+                    name: "Custom Allure Report",
+                    environments: {
+                        linux: { name: "Linux", matcher: () => true },
+                    },
+                };
+                """.trimIndent()
+            )
+        }
+
+        val buildResult = runBuild(projectDir, "allureReport")
+
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+
+        assertThat(projectDir.resolve("build/tmp/allureReport/allurerc.json"))
+            .doesNotExist()
+
+        val reportDir = projectDir.resolve("build/reports/allure-report/allureReport")
+        assertThat(reportDir.resolve("summary.json"))
+            .exists()
+
+        val invocations = projectDir.resolve("build/allure/commandline/node/invocations.txt").readText()
+        assertThat(invocations)
+            .contains("command=generate")
+            .contains("--config ${customConfig.canonicalPath}")
+            .contains("--output ${reportDir.canonicalPath}")
+    }
+
+    @Test
+    fun `allureReport should accept config-file as a task option`() {
+        assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS), "Fake Allure 3 runtime tests currently support Unix-like systems only")
+
+        val projectDir = createAllure3Project(singleFile = false)
+        val customConfig = projectDir.resolve("allurerc.mjs").apply {
+            writeText("export default { name: \"Task option config\" };\n")
+        }
+
+        val buildResult = runBuild(projectDir, "allureReport", "--config-file", customConfig.absolutePath)
+
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/tmp/allureReport/allurerc.json"))
+            .doesNotExist()
+
+        val invocations = projectDir.resolve("build/allure/commandline/node/invocations.txt").readText()
+        assertThat(invocations)
+            .contains("--config ${customConfig.absolutePath}")
+    }
+
+    @Test
     fun `allureServe should run open for Allure 3`() {
         assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS), "Fake Allure 3 runtime tests currently support Unix-like systems only")
 
@@ -118,6 +181,37 @@ class Allure3ReportIntegrationTest {
         assertThat(invocations)
             .contains("command=generate")
             .contains("command=open")
+            .contains("--port 4567")
+    }
+
+    @Test
+    fun `allureServe should use custom Allure 3 config file`() {
+        assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS), "Fake Allure 3 runtime tests currently support Unix-like systems only")
+
+        val projectDir = createAllure3Project(
+            singleFile = false,
+            extraAllureBlock = """
+                report.configFile = layout.projectDirectory.file('allurerc.mjs')
+            """.trimIndent()
+        )
+        val customConfig = projectDir.resolve("allurerc.mjs").apply {
+            writeText("export default { name: \"Serve config\" };\n")
+        }
+
+        val buildResult = runBuild(projectDir, "allureServe", "--port", "4567")
+
+        assertThat(buildResult.task(":allureServe")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/tmp/allureServe/allurerc.json"))
+            .doesNotExist()
+
+        val reportDir = projectDir.resolve("build/reports/allure-report/allureServe")
+        val invocations = projectDir.resolve("build/allure/commandline/node/invocations.txt").readText()
+        assertThat(invocations)
+            .contains("command=generate")
+            .contains("command=open")
+            .contains("--config ${customConfig.canonicalPath}")
+            .contains("--output ${reportDir.canonicalPath}")
             .contains("--port 4567")
     }
 
@@ -156,6 +250,41 @@ class Allure3ReportIntegrationTest {
         val buildFailure = requireNotNull(failure)
         assertThat(buildFailure.message)
             .contains("Allure 3 does not support Allure 2 allure.commandline")
+    }
+
+    @Test
+    fun `allureReport should reject custom config file for Allure 2`() {
+        val projectDir = File(tempDir, "allure2-custom-config-${System.nanoTime()}").apply { mkdirs() }
+        projectDir.resolve("settings.gradle").createNewFile()
+        createManualResults(projectDir)
+        val commandlineArchive = createFakeAllure2CommandlineZip(projectDir)
+        projectDir.resolve("allurerc.mjs").writeText("export default { name: \"Allure 2 unsupported\" };\n")
+
+        projectDir.resolve("build.gradle").writeText(
+            """
+            plugins {
+                id 'io.qameta.allure-report'
+            }
+
+            dependencies {
+                allureReport(files("${'$'}buildDir/manual-allure-results"))
+                allureCommandline(files('${commandlineArchive.absolutePath.replace("\\", "/")}'))
+            }
+
+            allure {
+                version = '2.38.1'
+                report.configFile = layout.projectDirectory.file('allurerc.mjs')
+            }
+            """.trimIndent()
+        )
+
+        val failure = runCatching {
+            runBuild(projectDir, "allureReport")
+        }.exceptionOrNull() as? UnexpectedBuildFailure
+
+        val buildFailure = requireNotNull(failure)
+        assertThat(buildFailure.message)
+            .contains("allure.report.configFile is supported only for Allure 3")
     }
 
     private fun createAllure3Project(singleFile: Boolean, extraAllureBlock: String = ""): File {
@@ -221,14 +350,25 @@ class Allure3ReportIntegrationTest {
             } >> "${'$'}LOG_FILE"
             if [ "${'$'}COMMAND" = "generate" ]; then
               CONFIG=""
+              OUTPUT=""
               while [ "${'$'}#" -gt 0 ]; do
-                if [ "${'$'}1" = "--config" ]; then
-                  CONFIG="${'$'}2"
-                  break
-                fi
-                shift
+                case "${'$'}1" in
+                  --config)
+                    CONFIG="${'$'}2"
+                    shift 2
+                    ;;
+                  --output|-o)
+                    OUTPUT="${'$'}2"
+                    shift 2
+                    ;;
+                  *)
+                    shift
+                    ;;
+                esac
               done
-              OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              if [ -z "${'$'}OUTPUT" ]; then
+                OUTPUT=${'$'}(sed -n 's/.*"output"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "${'$'}CONFIG" | head -n 1)
+              fi
               mkdir -p "${'$'}OUTPUT"
               printf '{}' > "${'$'}OUTPUT/summary.json"
             fi
@@ -271,6 +411,16 @@ class Allure3ReportIntegrationTest {
             nodeRoot.name
         ).inheritIO().start()
         check(process.waitFor() == 0) { "Failed to create fake Node.js archive" }
+        return archive
+    }
+
+    private fun createFakeAllure2CommandlineZip(projectDir: File): File {
+        val archive = projectDir.resolve("fake-allure2.zip")
+        ZipArchiveOutputStream(archive).use { zip ->
+            val root = "allure-2.38.1"
+            zip.addDirectory("$root/bin/")
+            zip.addFile("$root/bin/allure", "#!/bin/sh\nexit 0\n")
+        }
         return archive
     }
 


### PR DESCRIPTION
## Summary
<!--
Describe the change and why it is needed.
Link related issues with `Fixes #123` when applicable.
-->

Allure Gradle now supports custom Allure 3 config files for report generation and serve tasks. Users can configure `allure.report.configFile` or pass `--config-file=allurerc.mjs` to use Allure 3 features such as environments, custom grouping, report names, themes, and single-file output without re-running the Allure CLI manually.

This works for regular and aggregate reports, including CI setups that merge results from multiple projects or matrix jobs. When a custom config file is set, Allure 3 options are taken from that file while Gradle continues to control the report output directory.

```diff
 allure {
     report {
+        configFile.set(layout.projectDirectory.file("allurerc.mjs"))
     }
 }
```

```bash
./gradlew allureReport --config-file=allurerc.mjs
```

fixes #201 

## Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

## Notes
<!--
Call out compatibility concerns, follow-up work, or review context that will help maintainers.
-->

[cla]: https://cla-assistant.io/accept/allure-framework/allure2