### PR TITLE
Honor report-level dependsOnTests configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ might help:
 
 * Execute tests separately: `./gradlew test`
 * Use `--depends-on-tests` as follows (the option should come after the task name): `./gradlew allureReport --depends-on-tests`
-* Configure `allure.report.dependsOnTest.set(true)`
+* Configure `allure.report.dependsOnTests.set(true)`
 
 ```kotlin
 allure {
@@ -391,7 +391,7 @@ allure {
         // If the tests are fast (e.g. UP-TO-DATE or FROM-CACHE),
         // then you might want configure dependsOnTests.set(true) so you always
         // get the latest report from allureReport
-        dependsOnTests.set(false)
+        dependsOnTests.set(true)
     }
 }
 ```

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllurePluginFeatureMatrixTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/AllurePluginFeatureMatrixTest.kt
@@ -105,6 +105,34 @@ class AllurePluginFeatureMatrixTest {
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("runtimes")
+    fun `allureReport runs tests when report extension enables dependsOnTests`(runtime: TestAllureRuntime) {
+        val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/junit5-5.8.1")
+        AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)
+        projectDir.resolve("build.gradle").appendText(
+            """
+
+            allure {
+                report {
+                    dependsOnTests.set(true)
+                }
+            }
+            """.trimIndent()
+        )
+
+        val buildResult = AllureRuntimeMatrixSupport.build(projectDir, "allureReport")
+
+        AllureRuntimeMatrixSupport.assertRuntimeTasks(buildResult, runtime)
+        assertThat(buildResult.task(":test")?.outcome)
+            .`as`("allure.report.dependsOnTests should trigger test execution")
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(buildResult.task(":allureReport")?.outcome)
+            .isEqualTo(TaskOutcome.SUCCESS)
+        assertThat(projectDir.resolve("build/reports/allure-report/allureReport"))
+            .isNotEmptyDirectory()
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("runtimes")
     fun `allureReport stays no-source without depends-on-tests for both runtimes`(runtime: TestAllureRuntime) {
         val projectDir = AllureRuntimeMatrixSupport.copyFixture(tempDir, "src/it/junit5-5.8.1")
         AllureRuntimeMatrixSupport.configureRuntime(projectDir, runtime, usesReportRuntime = true)

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/AllureReportPlugin.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/AllureReportPlugin.kt
@@ -1,5 +1,6 @@
 package io.qameta.allure.gradle.report
 
+import io.qameta.allure.gradle.base.AllureExtension
 import io.qameta.allure.gradle.base.metadata.AllureResultType
 import io.qameta.allure.gradle.download.AllureDownloadPlugin
 import io.qameta.allure.gradle.download.tasks.DownloadAllure
@@ -9,6 +10,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.*
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import report
 
 /**
  * The plugin adds tasks to build Allure reports for the current project ([REPORT_TASK_NAME] and [SERVE_TASK_NAME]).
@@ -95,10 +97,12 @@ internal fun Project.registerReportTasks(
     // Ensure download task exists
     apply<AllureDownloadPlugin>()
     val download = tasks.named<DownloadAllure>(AllureDownloadPlugin.ALLURE_DOWNLOAD_TASK_NAME)
+    val reportExtension = the<AllureExtension>().report
 
     tasks.register<AllureReport>(reportTaskName) {
         description = "Builds Allure report from $aggConfigurationName dependencies"
         group = LifecycleBasePlugin.VERIFICATION_GROUP
+        dependsOnTests.convention(reportExtension.dependsOnTests)
         dependsOn(download)
         // This dependency ensures categories.json files are copied by the relevant copyCategories task
         // It enables users to update cagetories.json file in src/..., launch allureReport
@@ -111,6 +115,7 @@ internal fun Project.registerReportTasks(
     tasks.register<AllureServe>(serveTaskName) {
         description = "Builds Allure report from $aggConfigurationName dependencies and launches Allure server"
         group = LifecycleBasePlugin.VERIFICATION_GROUP
+        dependsOnTests.convention(reportExtension.dependsOnTests)
         dependsOn(download)
         // This dependency ensures categories.json files are copied by the relevant copyCategories task
         // It enables users to update categories.json file in src/..., launch allureReport


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add JUnit 5 adapter configuration (fixes #123\)
* Add an ability to customize report tasks
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Configuring `allure.report.dependsOnTests.set(true)` now causes report and serve tasks, including aggregate variants, to run the relevant tests first. This restores the documented workflow for users who want fresh results without passing `--depends-on-tests` on every invocation.

The default behavior remains unchanged, and the documentation now shows the correct property name and configuration.

fixes #216

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-gradle