### PR TITLE
Remove Gradle 9.6 deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,8 @@ jobs:
         os: [ 'ubuntu', 'windows' ]
         java-version: [ '17', '21' ]
         gradle:
-          - version: '9.4.1'
-            env-version: '9_4_1'
+          - version: '9.6.1'
+            env-version: '9_6_1'
           - version: '8.14.3'
             env-version: '8_14_3'
           - version: '8.11.1'

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ Tasks:
 
 The 3.x line targets modern Gradle and JVMs and aligns Spock with JUnit Platform:
 
-- Minimal supported Gradle version: 8.11 (tested with 8.11.1, 8.14.3, 9.5.1)
+- Minimal supported Gradle version: 8.11 (tested with 8.11.1, 8.14.3, 9.6.1)
 - Java 17 and 21 are supported
 - Spock 2 (Groovy 4) runs on JUnit Platform and should use the `allure-spock2` adapter
 

--- a/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterBasePlugin.kt
+++ b/allure-adapter-plugin/src/main/kotlin/io/qameta/allure/gradle/adapter/AllureAdapterBasePlugin.kt
@@ -59,7 +59,7 @@ open class AllureAdapterBasePlugin : Plugin<Project> {
             }
         }
 
-        val allureRawResultDirs by configurations.creating {
+        val allureRawResultDirs = configurations.create("allureRawResultDirs") {
             description = "gather all allure-results folders in the current project"
             isVisible = false
             isCanBeConsumed = false
@@ -67,7 +67,7 @@ open class AllureAdapterBasePlugin : Plugin<Project> {
             extendsFrom(rawResultElements)
         }
 
-        val copyCategories by tasks.registering(CopyCategories::class) {
+        val copyCategories = tasks.register<CopyCategories>("copyCategories") {
             description = "Copies categories.json to allure-results folders"
             destinationDirs.set(allureRawResultDirs)
         }

--- a/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
+++ b/allure-plugin/src/test/kotlin/io/qameta/allure/gradle/report/DslTest.kt
@@ -27,17 +27,24 @@ class DslTest {
 
     @ParameterizedTest(name = "{1} [{0}]")
     @MethodSource("getFrameworks")
-    fun `build script should compile`(version: String, project: String) {
+    fun `build script should compile without Allure deprecation warnings`(version: String, project: String) {
         val gradleRunner = GradleRunnerRule()
             .rootDir(tempDir)
             .version(version)
             .project(project)
-            .tasks("testDsl")
+            .tasks("--warning-mode=all", "testDsl")
             .build()
 
         assertThat(gradleRunner.buildResult.tasks).`as`("testDsl task status")
             .filteredOn { task -> task.path == ":testDsl" }
             .extracting("outcome")
             .containsExactly(TaskOutcome.SUCCESS)
+
+        assertThat(gradleRunner.buildResult.output).`as`("Gradle deprecation warnings")
+            .doesNotContain(
+                "The 'val name by creating { }' property delegate syntax has been deprecated.",
+                "The 'val name by registering(Type::class) { }' property delegate syntax has been deprecated.",
+                "Using a Project object as a dependency notation has been deprecated.",
+            )
     }
 }

--- a/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/AllureReportPlugin.kt
+++ b/allure-report-plugin/src/main/kotlin/io/qameta/allure/gradle/report/AllureReportPlugin.kt
@@ -75,7 +75,7 @@ internal fun Project.registerReportTasks(
         }
     }
 
-    val allureGenerateCategories by configurations.creating {
+    val allureGenerateCategories = configurations.create("allureGenerateCategories") {
         extendsFrom(allureAggregate)
 
         description = "Contains all the projects for aggregating Allure results"
@@ -90,7 +90,7 @@ internal fun Project.registerReportTasks(
     // However, it defeats Gradle's task dependency tracking: https://github.com/gradle/gradle/issues/16910
     dependencies {
         for (p in projects) {
-            allureAggregate(create(p))
+            allureAggregate(project(mapOf("path" to p.path)))
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 group = "io.qameta.allure"
 
 val testGradleVersionProperty = "testGradleVersion"
-val defaultTestGradleVersion = "9.5.1"
+val defaultTestGradleVersion = "9.6.1"
 
 allprojects {
     tasks.withType<Test>().configureEach {

--- a/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleTestVersion.java
+++ b/testkit-jupiter/src/main/java/io/qameta/allure/gradle/rule/GradleTestVersion.java
@@ -7,7 +7,7 @@ public final class GradleTestVersion {
 
     public static final String PROPERTY_NAME = "testGradleVersion";
 
-    public static final String DEFAULT_VERSION = "9.5.1";
+    public static final String DEFAULT_VERSION = "9.6.1";
 
     private GradleTestVersion() {
     }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add JUnit 5 adapter configuration (fixes #123\)
* Add an ability to customize report tasks
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Using the Allure Gradle plugin with Gradle 9.6 no longer emits deprecation warnings for configuration and task registration or project dependency notation. This keeps builds clean and prepares the affected plugin paths for Gradle 10.

Compatibility with Gradle 8.11 and newer is preserved, while the default and CI coverage now include Gradle 9.6.1 to prevent regressions.

fixes #212

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-gradle